### PR TITLE
Remove deprecated GTK CSS values

### DIFF
--- a/src/dash-button.vala
+++ b/src/dash-button.vala
@@ -68,7 +68,6 @@ public class DashButton : FlatButton, Fadable
         {
             var style = new Gtk.CssProvider ();
             style.load_from_data ("* {padding: 6px 8px 6px 8px;
-                                      -GtkWidget-focus-line-width: 0px;
                                      }", -1);
             this.get_style_context ().add_provider (style, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
         }

--- a/src/flat-button.vala
+++ b/src/flat-button.vala
@@ -24,19 +24,6 @@ public class FlatButton : Gtk.Button
     construct
     {
         SlickGreeter.add_style_class (this);
-        try
-        {
-            var style = new Gtk.CssProvider ();
-            style.load_from_data ("* {-GtkButton-child-displacement-x: 0px;
-                                      -GtkButton-child-displacement-y: 0px;
-                                      -GtkWidget-focus-line-width: 1px;
-                                      }", -1);
-            get_style_context ().add_provider (style, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-        }
-        catch (Error e)
-        {
-            debug ("Internal error loading session chooser style: %s", e.message);
-        }
     }
 
     public override bool button_press_event (Gdk.EventButton event)


### PR DESCRIPTION
Based on http://bazaar.launchpad.net/~unity-greeter-team/unity-greeter/trunk/revision/2108