### PR TITLE
Remove upstart as its no longer needed

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -26,7 +26,6 @@ Package: slick-greeter
 Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
-         upstart
 Recommends: lightdm
 Suggests: lightdm-remote-session-freerdp,
           lightdm-remote-session-uccsconfigure,

--- a/src/slick-greeter.vala
+++ b/src/slick-greeter.vala
@@ -447,7 +447,6 @@ public class SlickGreeter
         Environment.set_variable ("GTK_MODULES", "atk-bridge", false);
 
         Pid atspi_pid = 0;
-        Pid upstart_pid = 0;
 
         try
         {
@@ -556,18 +555,6 @@ public class SlickGreeter
         Gtk.main ();
 
         debug ("Cleaning up");
-
-        if (upstart_pid != 0)
-        {
-            Posix.kill (upstart_pid, Posix.SIGTERM);
-            int status;
-            Posix.waitpid (upstart_pid, out status, 0);
-            if (Process.if_exited (status))
-                debug ("Upstart exited with return value %d", Process.exit_status (status));
-            else
-                debug ("Upstart terminated with signal %d", Process.term_sig (status));
-            upstart_pid = 0;
-        }
 
         if (atspi_pid != 0)
         {


### PR DESCRIPTION
Based on http://bazaar.launchpad.net/~unity-greeter-team/unity-greeter/trunk/revision/2051

as indicator support was removed upstart isn't used for anything.