### PR TITLE
add required (on BSD, not on GNU) filename argument to find command in files/Makefile.in

### DIFF
--- a/files/Makefile.in
+++ b/files/Makefile.in
@@ -7,7 +7,7 @@ distclean:
 maintainer-clean:
 
 install:
-	find -mindepth 1 -maxdepth 1 -type d -exec cp -R {} $(DESTDIR)/ \;
+	find . -mindepth 1 -maxdepth 1 -type d -exec cp -R {} $(DESTDIR)/ \;
 
 uninstall:
-	find -mindepth 1 -type f -exec rm $(DESTDIR)/{} \;
+	find . -mindepth 1 -type f -exec rm $(DESTDIR)/{} \;


### PR DESCRIPTION
in GNU, the find command assumes $PWD for the file argument if there isn't one. in BSD, it REQUIRES the file argument.