### PR TITLE
install an example slick-greeter.conf file

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -3,6 +3,9 @@
 xgreeterdir = $(datarootdir)/xgreeters
 dist_xgreeter_DATA = slick-greeter.desktop
 
+greeterconfdir = $(sysconfdir)/lightdm
+dist_greeterconf_DATA = slick-greeter.conf
+
 dist_pkgdata_DATA = \
 	a11y.svg \
 	active.png \

--- a/data/slick-greeter.conf
+++ b/data/slick-greeter.conf
@@ -1,0 +1,48 @@
+# LightDM GTK+ Configuration
+# Available configuration options listed below.
+#
+# background = Background file to use, either an image path or a color (e.g. #772953)
+# background-color = Background color (e.g. #772953), set before wallpaper is seen
+# draw-user-backgrounds = Whether to draw user backgrounds (true or false)
+# draw-grid = Whether to draw an overlay grid (true or false)
+# show-hostname = Whether to show the hostname in the menubar (true or false)
+# logo = Logo file to use
+# background-logo = Background logo file to use
+# theme-name = GTK+ theme to use
+# icon-theme-name = Icon theme to use
+# font-name = Font to use
+# xft-antialias = Whether to antialias Xft fonts (true or false)
+# xft-dpi = Resolution for Xft in dots per inch
+# xft-hintstyle = What degree of hinting to use (hintnone/hintslight/hintmedium/hintfull)
+# xft-rgba = Type of subpixel antialiasing (none/rgb/bgr/vrgb/vbgr)
+# onscreen-keyboard = Whether to enable the onscreen keyboard (true or false)
+# high-contrast = Whether to use a high contrast theme (true or false)
+# screen-reader = Whether to enable the screen reader (true or false)
+# play-ready-sound = A sound file to play when the greeter is ready
+# hidden-users = List of usernames that are hidden until a special key combination is hit
+# group-filter = List of groups that users must be part of to be shown (empty list shows all users)
+# idle-timeout = Number of seconds of inactivity before blanking the screen. Set to 0 to never timeout
+# enable-hidpi = Whether to enable HiDPI support (on/off/auto)
+[greeter]
+#background=
+#background-color=
+#draw-user-backgrounds=
+#draw-grid=
+#show-hostname=
+#logo=
+#background-logo=
+#theme-name=
+#icon-theme-name=
+#font-name=
+#xft-antialias=
+#xft-dpi=
+#xft-hintstyle=
+#xft-rgba=
+#onscreen-keyboard=
+#high-contrast=
+#screen-reader=
+#play-ready-sound=
+#hidden-users=
+#group-filter=
+#idle-timeout=
+#enable-hidpi=


### PR DESCRIPTION
This resolves #35 i.e. helps users who are not using lightdm-settings to override distro specific configuration