### PR TITLE
Error text readability improvement

### DIFF
--- a/src/prompt-box.vala
+++ b/src/prompt-box.vala
@@ -452,11 +452,11 @@ public class PromptBox : FadableBox
     {
         var label = new FadingLabel (text);
 
-        label.override_font (Pango.FontDescription.from_string ("Ubuntu 10"));
+        label.override_font (Pango.FontDescription.from_string ("Ubuntu Bold 10"));
 
         Gdk.RGBA color = { 1.0f, 1.0f, 1.0f, 1.0f };
         if (is_error)
-            color.parse ("#df382c");
+            color.parse ("#ffd64d");
         label.override_color (Gtk.StateFlags.NORMAL, color);
 
         label.xalign = 0.0f;


### PR DESCRIPTION
Error text colour and slight font style change, readability improvement. Hopefully helpful for all, especially those with any form of visual impairment, 

Before and after comparisons using a selection of different colour backgrounds
http://pasteall.org/pic/show.php?id=116307
http://pasteall.org/pic/show.php?id=116308
http://pasteall.org/pic/show.php?id=116309
http://pasteall.org/pic/show.php?id=116310
http://pasteall.org/pic/show.php?id=116311

Similar colour change was previously committed for MDM themes https://github.com/linuxmint/mint-mdm-themes/commit/bbdc5d7aa7e31be375f18adf69948e09d9f55bf0