### PR TITLE
Onscreen keyboard height increase

### DIFF
--- a/src/menubar.vala
+++ b/src/menubar.vala
@@ -522,8 +522,8 @@ public class MenuBar : Gtk.MenuBar
             var monitor = screen.get_monitor_at_window (get_window ());
             Gdk.Rectangle geom;
             screen.get_monitor_geometry (monitor, out geom);
-            keyboard_window.move (geom.x, geom.y + geom.height - 200);
-            keyboard_window.resize (geom.width, 200);
+            keyboard_window.move (geom.x, geom.y + geom.height - 250);
+            keyboard_window.resize (geom.width, 250);
         }
 
         keyboard_window.visible = item.active;


### PR DESCRIPTION
Onscreen keyboard height increase provides larger keys, helpful for touch-screen and tablet users. Closer match to Mint's on screen keyboard height (discounting the panel height).

Before
http://pasteall.org/pic/show.php?id=116312

After
http://pasteall.org/pic/show.php?id=116313

Mint (Cinnamon) on screen keyboard height compare
http://pasteall.org/pic/show.php?id=116315