### PR TITLE
kill onboard and orca on session startup

### DIFF
--- a/src/main-window.vala
+++ b/src/main-window.vala
@@ -193,6 +193,12 @@ public class MainWindow : Gtk.Window
         background.set_surface (Gdk.cairo_create (get_window ()).get_target ());
     }
 
+    public void before_session_start()
+    {
+        debug ("Killing orca and onboard");
+        menubar.cleanup();
+    }
+
     private void monitors_changed_cb (Gdk.Screen screen)
     {
         int primary = screen.get_primary_monitor ();

--- a/src/slick-greeter.vala
+++ b/src/slick-greeter.vala
@@ -229,6 +229,8 @@ public class SlickGreeter
         // bg.draw_full (c, Background.DrawFlags.NONE);
         // c = null;
         // refresh_background (screen, background_surface);
+        
+        main_window.before_session_start();
 
         if (test_mode)
         {


### PR DESCRIPTION
onboard-1.4.1 doesn't exit cleanly and the upstream fix wont work for slick

http://bazaar.launchpad.net/~onboard/onboard/trunk/revision/2278

It seems to be a recurring issue

https://bugs.launchpad.net/ubuntu/+source/onboard/+bug/978430

output for test-mode without pr

```
[+3.02s] DEBUG: user-list.vala:892: Start session for no-password
[+3.03s] DEBUG: slick-greeter.vala:234: Successfully logged in! Quitting...
[+3.03s] DEBUG: slick-greeter.vala:692: Cleaning up
[+3.03s] DEBUG: slick-greeter.vala:700: AT-SPI exited with return value 0
[+3.03s] DEBUG: slick-greeter.vala:706: Exiting
[leigh@localhost ~]$ Traceback (most recent call last):
  File "/usr/lib64/python3.6/site-packages/Onboard/Timer.py", line 86, in _cb_timer
    if not self.on_timer():
  File "/usr/lib64/python3.6/site-packages/Onboard/Timer.py", line 97, in on_timer
    return self._callback(*self._callback_args)
  File "/usr/lib64/python3.6/site-packages/Onboard/OnboardGtk.py", line 713, in reload_layout
    self.load_layout(layout_filename, color_scheme_filename)
  File "/usr/lib64/python3.6/site-packages/Onboard/OnboardGtk.py", line 736, in load_layout
    self.keyboard.set_layout(layout, color_scheme, vk)
  File "/usr/lib64/python3.6/site-packages/Onboard/Keyboard.py", line 928, in set_layout
    self.on_layout_loaded()
  File "/usr/lib64/python3.6/site-packages/Onboard/Keyboard.py", line 951, in on_layout_loaded
    self.commit_ui_updates()
  File "/usr/lib64/python3.6/site-packages/Onboard/Keyboard.py", line 2212, in commit_ui_updates
    self.update_layout()   # after suggestions!
  File "/usr/lib64/python3.6/site-packages/Onboard/Keyboard.py", line 2232, in update_layout
    view.update_layout()
  File "/usr/lib64/python3.6/site-packages/Onboard/KeyboardWidget.py", line 485, in update_layout
    rect, self.get_base_aspect_rect())
  File "/usr/lib64/python3.6/site-packages/Onboard/KeyboardWidget.py", line 497, in _get_aspect_corrected_layout_rect
    orientation_co = self.get_kbd_window().get_orientation_config_object()
AttributeError: 'NoneType' object has no attribute 'get_orientation_config_object'
/usr/lib64/python3.6/site-packages/Onboard/Timer.py:79: Warning: Source ID 77 was not found when attempting to remove it
  GLib.source_remove(self._timer)
```

with pr it exits cleanly

```
[+2.78s] DEBUG: user-list.vala:892: Start session for no-password
[+2.78s] DEBUG: main-window.vala:198: Killing orca and onboard
[+2.78s] DEBUG: slick-greeter.vala:237: Successfully logged in! Quitting...
[+2.78s] DEBUG: slick-greeter.vala:708: Cleaning up
[+2.78s] DEBUG: slick-greeter.vala:716: AT-SPI exited with return value 0
[+2.78s] DEBUG: slick-greeter.vala:722: Exiting
[leigh@localhost ~]$ slick-greeter --test-mode
```

if you hold the mouse click too long there is a harmless warning

```
[+2.37s] DEBUG: user-list.vala:892: Start session for no-password
[+2.38s] DEBUG: main-window.vala:198: Killing orca and onboard
[+2.38s] DEBUG: slick-greeter.vala:237: Successfully logged in! Quitting...
[+2.38s] DEBUG: slick-greeter.vala:708: Cleaning up
[+2.38s] DEBUG: slick-greeter.vala:716: AT-SPI exited with return value 0
[+2.38s] DEBUG: slick-greeter.vala:722: Exiting
21:15:15.344 WARNING Onboard.Keyboard: Releasing still pressed key 'RTRN'
[leigh@localhost ~]$ slick-greeter --test-mode
```