### PR TITLE
Make slick-greeter obey local config before falling to default

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ Configuration file format for /etc/lightdm/slick-greeter.conf
     # group-filter=List of groups that users must be part of to be shown (empty list shows all users)
     # idle-timeout=Number of seconds of inactivity before blanking the screen. Set to 0 to never timeout
     # enable-hidpi=Whether to enable HiDPI support (on/off/auto)
-    [greeter]
+    [Greeter]

--- a/src/settings.vala
+++ b/src/settings.vala
@@ -200,5 +200,5 @@ public class UGSettings
     }
 
     private const string SCHEMA = "x.dm.slick-greeter";
-    private const string GROUP_NAME = "Greeter";
+    private const string GROUP_NAME = "greeter";
 }

--- a/src/settings.vala
+++ b/src/settings.vala
@@ -200,5 +200,5 @@ public class UGSettings
     }
 
     private const string SCHEMA = "x.dm.slick-greeter";
-    private const string GROUP_NAME = "greeter";
+    private const string GROUP_NAME = "Greeter";
 }


### PR DESCRIPTION
Should fix #52 as per the discussion. Group_Name should be set to lower case as is lightdm-gtk-greeter 