### PR TITLE
add GNOME 3.26 xorg session and ubuntu xorg equivalent session

### DIFF
--- a/files/usr/share/slick-greeter/badges/gnome-xorg.svg
+++ b/files/usr/share/slick-greeter/badges/gnome-xorg.svg
@@ -1,0 +1,1 @@
+gnome.svg

--- a/files/usr/share/slick-greeter/badges/ubuntu-xorg.svg
+++ b/files/usr/share/slick-greeter/badges/ubuntu-xorg.svg
@@ -1,0 +1,1 @@
+ubuntu.svg

--- a/src/slick-greeter.vala
+++ b/src/slick-greeter.vala
@@ -185,6 +185,8 @@ public class SlickGreeter
         sessions.append ("deepin");
         sessions.append ("openbox");
         sessions.append ("awesome");
+        sessions.append ("gnome-xorg");
+        sessions.append ("ubuntu-xorg");
 
         foreach (string session in sessions) {
             var path = Path.build_filename  ("/usr/share/xsessions/", session.concat(".desktop"), null);


### PR DESCRIPTION
This PR adds the two new sessions available in Ubuntu 17.10.

built and tested here on ubuntu 17.10 https://launchpad.net/~ubuntubudgie-dev/+archive/ubuntu/artful-proposed/+sourcepub/8251291/+listing-archive-extra