### PR TITLE
Add option to show GUI on a specific monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,5 @@ Configuration file format for /etc/lightdm/slick-greeter.conf
     # hidden-users=List of usernames that are hidden until a special key combination is hit
     # group-filter=List of groups that users must be part of to be shown (empty list shows all users)
     # enable-hidpi=Whether to enable HiDPI support (on/off/auto)
+    # only-on-monitor=Sets the monitor on which to show the login window, -1 means "follow the mouse"
     [Greeter]

--- a/data/slick-greeter.1
+++ b/data/slick-greeter.1
@@ -107,5 +107,8 @@ List of groups that users must be part of to be shown (empty list shows all user
 .TP
 .B enable-hidpi=
 Whether to enable HiDPI support (on/off/auto)
+.TP
+.B only_on_monitor=
+Sets the monitor on which to show the login window, -1 means "follow the mouse"
 .SH SEE ALSO
 .B lightdm

--- a/data/x.dm.slick-greeter.gschema.xml
+++ b/data/x.dm.slick-greeter.gschema.xml
@@ -127,5 +127,9 @@
       <default>false</default>
       <summary>Whether to activate numlock. This features requires the installation of numlockx.</summary>
     </key>
+    <key name="only-on-monitor" type="s">
+      <default>'auto'</default>
+      <summary>Monitor on which to show the GUI</summary>
+    </key>
   </schema>
 </schemalist>

--- a/src/settings.vala
+++ b/src/settings.vala
@@ -47,6 +47,7 @@ public class UGSettings
     public const string KEY_GROUP_FILTER = "group-filter";
     public const string KEY_ENABLE_HIDPI = "enable-hidpi";
     public const string KEY_ACTIVATE_NUMLOCK = "activate-numlock";
+    public const string KEY_ONLY_ON_MONITOR = "only-on-monitor";
 
     public static bool get_boolean (string key)
     {
@@ -127,6 +128,7 @@ public class UGSettings
             string_keys.append (KEY_XFT_HINTSTYLE);
             string_keys.append (KEY_XFT_RGBA);
             string_keys.append (KEY_ENABLE_HIDPI);
+            string_keys.append (KEY_ONLY_ON_MONITOR);
 
             var bool_keys = new List<string> ();
             bool_keys.append (KEY_DRAW_USER_BACKGROUNDS);


### PR DESCRIPTION
This adds the option "only-on-monitor".
Default is "auto", which means "Follow the mouse", like it was without this option.
This goes together with https://github.com/linuxmint/lightdm-settings/pull/17