### PR TITLE
Settings: Reset config keys to default if not in config file

### DIFF
--- a/src/settings.vala
+++ b/src/settings.vala
@@ -107,108 +107,122 @@ public class UGSettings
     {
         try {
             var path = "/etc/lightdm/slick-greeter.conf";
+            var gsettings = new Settings (SCHEMA);
+            var keyfile = new KeyFile ();
+
             if (FileUtils.test (path, FileTest.EXISTS))
             {
-                var gsettings = new Settings (SCHEMA);
-                var keyfile = new KeyFile ();
                 keyfile.load_from_file (path, KeyFileFlags.NONE);
+            }
 
-                if (keyfile.has_group (GROUP_NAME)) {
+            var string_keys = new List<string> ();
+            string_keys.append (KEY_BACKGROUND);
+            string_keys.append (KEY_BACKGROUND_COLOR);
+            string_keys.append (KEY_LOGO);
+            string_keys.append (KEY_OTHER_MONITORS_LOGO);
+            string_keys.append (KEY_THEME_NAME);
+            string_keys.append (KEY_ICON_THEME_NAME);
+            string_keys.append (KEY_FONT_NAME);
+            string_keys.append (KEY_PLAY_READY_SOUND);
+            string_keys.append (KEY_XFT_HINTSTYLE);
+            string_keys.append (KEY_XFT_RGBA);
+            string_keys.append (KEY_ENABLE_HIDPI);
 
-                    var string_keys = new List<string> ();
-                    string_keys.append (KEY_BACKGROUND);
-                    string_keys.append (KEY_BACKGROUND_COLOR);
-                    string_keys.append (KEY_LOGO);
-                    string_keys.append (KEY_OTHER_MONITORS_LOGO);
-                    string_keys.append (KEY_THEME_NAME);
-                    string_keys.append (KEY_ICON_THEME_NAME);
-                    string_keys.append (KEY_FONT_NAME);
-                    string_keys.append (KEY_PLAY_READY_SOUND);
-                    string_keys.append (KEY_XFT_HINTSTYLE);
-                    string_keys.append (KEY_XFT_RGBA);
-                    string_keys.append (KEY_ENABLE_HIDPI);
+            var bool_keys = new List<string> ();
+            bool_keys.append (KEY_DRAW_USER_BACKGROUNDS);
+            bool_keys.append (KEY_DRAW_GRID);
+            bool_keys.append (KEY_SHOW_HOSTNAME);
+            bool_keys.append (KEY_SHOW_POWER);
+            bool_keys.append (KEY_SHOW_A11Y);
+            bool_keys.append (KEY_SHOW_CLOCK);
+            bool_keys.append (KEY_SHOW_KEYBOARD);
+            bool_keys.append (KEY_SHOW_QUIT);
+            bool_keys.append (KEY_XFT_ANTIALIAS);
+            bool_keys.append (KEY_ACTIVATE_NUMLOCK);
 
-                    var bool_keys = new List<string> ();
-                    bool_keys.append (KEY_DRAW_USER_BACKGROUNDS);
-                    bool_keys.append (KEY_DRAW_GRID);
-                    bool_keys.append (KEY_SHOW_HOSTNAME);
-                    bool_keys.append (KEY_SHOW_POWER);
-                    bool_keys.append (KEY_SHOW_A11Y);
-                    bool_keys.append (KEY_SHOW_CLOCK);
-                    bool_keys.append (KEY_SHOW_KEYBOARD);
-                    bool_keys.append (KEY_SHOW_QUIT);
-                    bool_keys.append (KEY_XFT_ANTIALIAS);
-                    bool_keys.append (KEY_ACTIVATE_NUMLOCK);
+            var int_keys = new List<string> ();
+            int_keys.append (KEY_XFT_DPI);
 
-                    var int_keys = new List<string> ();
-                    int_keys.append (KEY_XFT_DPI);
+            var strv_keys = new List<string> ();
+            strv_keys.append (KEY_HIDDEN_USERS);
+            strv_keys.append (KEY_GROUP_FILTER);
 
-                    var strv_keys = new List<string> ();
-                    strv_keys.append (KEY_HIDDEN_USERS);
-                    strv_keys.append (KEY_GROUP_FILTER);
-
-                    foreach (string key in string_keys)
-                    {
-                        if (keyfile.has_key (GROUP_NAME, key)) {
-                            try {
-                                var value = keyfile.get_string (GROUP_NAME, key);
-                                debug ("Overriding dconf setting for %s with %s", key, value);
-                                gsettings.set_string (key, value);
-                            }
-                            catch (Error e) {
-                                warning ("Failed to apply %s from configuration file: %s", key, e.message);
-                            }
+            foreach (string key in string_keys)
+            {
+                if (keyfile.has_group (GROUP_NAME) && keyfile.has_key (GROUP_NAME, key)) {
+                    try {
+                        var value = keyfile.get_string (GROUP_NAME, key);
+                        debug ("Overriding dconf setting for %s with %s", key, value);
+                        gsettings.set_string (key, value);
                         }
-                    }
-
-                    foreach (string key in bool_keys)
-                    {
-                        if (keyfile.has_key (GROUP_NAME, key)) {
-                            try {
-                                var value = keyfile.get_boolean (GROUP_NAME, key);
-                                debug ("Overriding dconf setting for %s", key);
-                                gsettings.set_boolean (key, value);
-                            }
-                            catch (Error e) {
-                                warning ("Failed to apply %s from configuration file: %s", key, e.message);
-                            }
-                        }
-                    }
-
-                    foreach (string key in int_keys)
-                    {
-                        if (keyfile.has_key (GROUP_NAME, key)) {
-                            try {
-                                var value = keyfile.get_integer (GROUP_NAME, key);
-                                debug ("Overriding dconf setting for %s with %d", key, value);
-                                gsettings.set_int (key, value);
-                            }
-                            catch (Error e) {
-                                warning ("Failed to apply %s from configuration file: %s", key, e.message);
-                            }
-                        }
-                    }
-
-                    foreach (string key in strv_keys)
-                    {
-                        if (keyfile.has_key (GROUP_NAME, key)) {
-                            try {
-                                var value = keyfile.get_string_list (GROUP_NAME, key);
-                                debug ("Overriding dconf setting for %s", key);
-                                gsettings.set_strv (key, value);
-                            }
-                            catch (Error e) {
-                                warning ("Failed to apply %s from configuration file: %s", key, e.message);
-                            }
-                        }
+                    catch (Error e) {
+                        warning ("Failed to apply %s from configuration file: %s", key, e.message);
                     }
                 }
+                else {
+                    gsettings.reset(key);
+                    debug ("Resetting dconf setting for %s to default", key);
+                }
             }
-        } catch (Error e) {
+
+            foreach (string key in bool_keys)
+            {
+                if (keyfile.has_group (GROUP_NAME) && keyfile.has_key (GROUP_NAME, key)) {
+                    try {
+                        var value = keyfile.get_boolean (GROUP_NAME, key);
+                        debug ("Overriding dconf setting for %s", key);
+                        gsettings.set_boolean (key, value);
+                    }
+                    catch (Error e) {
+                        warning ("Failed to apply %s from configuration file: %s", key, e.message);
+                    }
+                }
+                else {
+                    gsettings.reset(key);
+                    debug ("Resetting dconf setting for %s to default", key);
+                }
+            }
+
+            foreach (string key in int_keys)
+            {
+                if (keyfile.has_group (GROUP_NAME) && keyfile.has_key (GROUP_NAME, key)) {
+                    try {
+                        var value = keyfile.get_integer (GROUP_NAME, key);
+                        debug ("Overriding dconf setting for %s with %d", key, value);
+                        gsettings.set_int (key, value);
+                    }
+                    catch (Error e) {
+                        warning ("Failed to apply %s from configuration file: %s", key, e.message);
+                    }
+                }
+                else {
+                    gsettings.reset(key);
+                    debug ("Resetting dconf setting for %s to default", key);
+                }
+            }
+
+            foreach (string key in strv_keys)
+            {
+                if (keyfile.has_group (GROUP_NAME) && keyfile.has_key (GROUP_NAME, key)) {
+                    try {
+                        var value = keyfile.get_string_list (GROUP_NAME, key);
+                        debug ("Overriding dconf setting for %s", key);
+                        gsettings.set_strv (key, value);
+                    }
+                    catch (Error e) {
+                        warning ("Failed to apply %s from configuration file: %s", key, e.message);
+                    }
+                }
+                else {
+                    gsettings.reset(key);
+                    debug ("Resetting dconf setting for %s to default", key);
+                }
+            }
+        }
+        catch (Error e) {
             warning ("Error in apply_conf_settings (): %s", e.message);
         }
     }
-
     private const string SCHEMA = "x.dm.slick-greeter";
     private const string GROUP_NAME = "Greeter";
 }


### PR DESCRIPTION
If a setting key has been removed from the config file (e.g. using lightdm-settings) slick-greeter keeps using that user-defined setting until it is readded to the config file with an empty value or with a different value.

This small change makes sure slick-greeter always uses the default from the system's gsettings, if there is no corresponding settings key inside of the config file.