### PR TITLE
greeter: Avoid expensive Python calls when it isn't needed

### DIFF
--- a/src/slick-greeter.vala
+++ b/src/slick-greeter.vala
@@ -518,6 +518,11 @@ public class SlickGreeter
 
     private static void set_keyboard_layout ()
     {
+        /* Avoid expensive Python execution where possible */
+        if (!FileUtils.test("/etc/default/keyboard", FileTest.EXISTS)) {
+            return;
+        }
+
         try {
             Process.spawn_command_line_sync("/usr/bin/slick-greeter-set-keyboard-layout", null, null, null);
         }


### PR DESCRIPTION
On non Debian/Ubuntu systems, the /etc/default/keyboard path does not exist.
To prevent expensive Python startup (and hundreds/thousands of stats +
follow-up loads) we'll reduce to an initial early stat, i.e. if the
non-standard file exists only then will we exectute the helper stub.

This is most useful on systems that employ systemd for the X11 keyboard
configuration (`00-keyboard.conf` from systemd-localed) so that the X server
already has the correct layout upon starting up. This approach also avoids
unnecessary xkbcomp calls forcing recompilation of non-cached assets.

Signed-off-by: Ikey Doherty <ikey@solus-project.com>