### PR TITLE
Fix HiDPI auto-detection

### DIFF
--- a/files/usr/bin/slick-greeter-check-hidpi
+++ b/files/usr/bin/slick-greeter-check-hidpi
@@ -28,7 +28,7 @@ def get_window_scale():
             or (width_mm == 16 and height_mm == 10)):
             return 1
 
-        if rect.height < 1500:
+        if rect.height * monitor_scale < 1500:
             return 1
 
         if width_mm > 0 and height_mm > 0:


### PR DESCRIPTION
When calculating the rectangle height, using `get_monitor_geometry`
returns "application pixels", rather than "device pixels". We need to
multiply by the scale factor to convert to the correct value.

https://valadoc.org/gdk-3.0/Gdk.Screen.get_monitor_geometry.html