### PR TITLE
Fix background if image file is not readable

### DIFF
--- a/src/background.vala
+++ b/src/background.vala
@@ -697,7 +697,25 @@ public class Background : Gtk.Fixed
     private BackgroundLoader load_background (string? filename)
     {
         if (filename == null)
+        {
             filename = fallback_color;
+        } else
+        {
+    	    try
+    	    {
+              var file = File.new_for_path(filename);
+              var fileInfo = file.query_info(FileAttribute.ACCESS_CAN_READ, FileQueryInfoFlags.NONE, null);
+              if (!fileInfo.get_attribute_boolean(FileAttribute.ACCESS_CAN_READ))
+              {
+                  debug ("Can't read background file %s, falling back to %s", filename, system_background);
+                  filename = system_background;
+              }
+    	    }
+          catch
+          {
+              filename = system_background;
+          }
+        }
 
         var b = loaders.lookup (filename);
         if (b == null)


### PR DESCRIPTION
This fixes a bug, where we fell back to the defined background color, if
reading an image file failed.
If that file was a user background, we didn't fall back to the defined
system background before using the color, now we do.
Only if that one is not readable either, we fall back to the color.