### PR TITLE
Add support for login-window-alignment/offset and logo-positioning + dev documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ A configuration tool is available at https://github.com/linuxmint/lightdm-settin
 - Sessions are validated. If a default/chosen session isn't present on the system, the greeter scans for known sessions in /usr/share/xsessions and replaces the invalid session choice with a valid session.
 - You can take a screenshot by pressing PrintScrn. The screenshot is saved in /var/lib/lightdm/Screenshot.png.
 
+# Development
+
+- Requires `automake`, `autogen`, `gnome-common` and `vala` to setup a build
+- Build with `make`, binary lands in `src/slick-greeter`
+- Test with `src/slick-greeter --test-mode`, global slick-greeter.conf and x.dm.slick-greeter.gschema.xml are used
+- Deploy to system with `sudo mv src/slick-greeter /bin/slick-greeter`
+- If you change the global schema, recompile with `sudo glib-compile-schemas /usr/share/glib-2.0/schemas/`
+
 # Credit
 
 - Slick Greeter started as a fork of Unity Greeter 16.04.2, a greeter developed for Ubuntu by Canonical, which used indicators and unity-settings-daemon.
@@ -59,4 +67,9 @@ Configuration file format for /etc/lightdm/slick-greeter.conf
     # group-filter=List of groups that users must be part of to be shown (empty list shows all users)
     # enable-hidpi=Whether to enable HiDPI support (on/off/auto)
     # only-on-monitor=Sets the monitor on which to show the login window, -1 means "follow the mouse"
+    # main-align, alignment of loginbox; 0 = left = default; 50 = center; 100 = right
+    # main-xpos, x-offset (in px) of login-window, 0 = default
+    # main-ypos, y-offset (in px) of login-window, 0 = default
+    # logo-xpos, x-offset (in px) of logo, auto if logo-xpos + logo-ypos not set
+    # logo-ypos, y-offset (in px) of logo, auto if logo-xpos + logo-ypos not set
     [Greeter]

--- a/data/x.dm.slick-greeter.gschema.xml
+++ b/data/x.dm.slick-greeter.gschema.xml
@@ -131,5 +131,26 @@
       <default>'auto'</default>
       <summary>Monitor on which to show the GUI</summary>
     </key>
+    <key name="main-align" type="i">
+      <default>0</default>
+      <summary>Main window align; 0=left, 100=right</summary>
+    </key>
+    <key name="main-xpos" type="i">
+      <default>0</default>
+      <summary>Main window xpos</summary>
+    </key>
+    <key name="main-ypos" type="i">
+      <default>0</default>
+      <summary>Main window ypos</summary>
+    </key>
+
+    <key name="logo-xpos" type="i">
+      <default>-1</default>
+      <summary>Logo xpos</summary>
+    </key>
+    <key name="logo-ypos" type="i">
+      <default>-1</default>
+      <summary>Logo ypos</summary>
+    </key>
   </schema>
 </schemalist>

--- a/src/background.vala
+++ b/src/background.vala
@@ -204,8 +204,15 @@ class BackgroundLoader : Object
         if (logo != null)
         {
             bc.save ();
-            var y = (int) (image.height / grid_size - 2) * grid_size + grid_y_offset;
-            bc.translate (grid_x_offset, y);
+            var xpos = UGSettings.get_integer(UGSettings.KEY_LOGO_XPOS);
+            var ypos = UGSettings.get_integer(UGSettings.KEY_LOGO_YPOS);
+            if ( xpos == -1 || ypos == -1) {
+                // traditional behaviour if not set
+                var y = (int) (image.height / grid_size - 2) * grid_size + grid_y_offset;
+                bc.translate (grid_x_offset, y);
+            } else {
+                bc.translate (xpos, ypos);
+            }
             bc.set_source_surface (logo, 0, 0);
             bc.paint_with_alpha (1.0);
             bc.restore ();

--- a/src/main-window.vala
+++ b/src/main-window.vala
@@ -121,7 +121,9 @@ public class MainWindow : Gtk.Window
         back_button.clicked.connect (pop_list);
         align.add (back_button);
 
-        align = new Gtk.Alignment (0.0f, 0.5f, 0.0f, 1.0f);
+        // default value = 0 -> left
+        var main_align = 0.01f*UGSettings.get_integer(UGSettings.KEY_MAIN_ALIGN);
+        align = new Gtk.Alignment (main_align, 0.5f, 0.0f, 1.0f);
         align.show ();
         hbox.add (align);
 
@@ -155,6 +157,10 @@ public class MainWindow : Gtk.Window
             screen.monitors_changed.connect (monitors_changed_cb);
             monitors_changed_cb (screen);
         }
+
+        // set offset of main window with main-xpos / main-ypos
+        align.top_padding = UGSettings.get_integer(UGSettings.KEY_MAIN_XPOS);
+        align.left_padding = UGSettings.get_integer(UGSettings.KEY_MAIN_YPOS);
 
         /* Force a call on login_box.show()...
             This fixes the following issue:

--- a/src/settings.vala
+++ b/src/settings.vala
@@ -48,6 +48,11 @@ public class UGSettings
     public const string KEY_ENABLE_HIDPI = "enable-hidpi";
     public const string KEY_ACTIVATE_NUMLOCK = "activate-numlock";
     public const string KEY_ONLY_ON_MONITOR = "only-on-monitor";
+    public const string KEY_MAIN_ALIGN = "main-align";
+    public const string KEY_MAIN_XPOS = "main-xpos";
+    public const string KEY_MAIN_YPOS = "main-ypos";
+    public const string KEY_LOGO_XPOS = "logo-xpos";
+    public const string KEY_LOGO_YPOS = "logo-ypos";
 
     public static bool get_boolean (string key)
     {
@@ -144,6 +149,11 @@ public class UGSettings
 
             var int_keys = new List<string> ();
             int_keys.append (KEY_XFT_DPI);
+            int_keys.append (KEY_MAIN_ALIGN);
+            int_keys.append (KEY_MAIN_XPOS);
+            int_keys.append (KEY_MAIN_YPOS);
+            int_keys.append (KEY_LOGO_XPOS);
+            int_keys.append (KEY_LOGO_YPOS);
 
             var strv_keys = new List<string> ();
             strv_keys.append (KEY_HIDDEN_USERS);


### PR DESCRIPTION
Keep old defaults
Add settings-keys, config-schema-keys and documentation of new config-keys to readme
Add documentation on how to develop for this, as setting up automake-autogen-gnome-vala-make was 1/3 of the work for me. (Maybe move to different .md file?)

Should fix #92 and #105 + allow left-center-right alignment 
REQUIRES SCHEMA RECOMPILE FOR TESTING (see README with improved dev tips)