### PR TITLE
Fixed default session for manual user entry.

### DIFF
--- a/src/user-list.vala
+++ b/src/user-list.vala
@@ -854,6 +854,10 @@ public class UserList : GreeterList
         }
         e.background = background;
         e.is_active = is_active;
+        if ( session == null)
+        {
+            session = default_session;
+        }
         e.session = SlickGreeter.validate_session (session);
         e.label = label;
         e.set_show_message_icon (has_messages);


### PR DESCRIPTION
Solution for issue #130 

When using manual user entry (for sssd/LDAP), the default desktop session was always getting pulled from an arbitrary list in the `slick-greeter.vala:get_default_session` function instead of using the `user-session` conf variable.

When `add_user` is called with `session=null` for adding the manual user, session will now be set to the `UserList::default_session` that is set from the `hint` that is set from the `user-session` variable in the conf files.