### PR TITLE
Fix FTBFS with vala 0.43.91

### DIFF
--- a/src/list-stack.vala
+++ b/src/list-stack.vala
@@ -72,7 +72,7 @@ public class ListStack : Gtk.Fixed
 
         return_if_fail (children != null);
 
-        unowned List<Gtk.Widget> prev = children.last ().prev;
+        unowned List<weak Gtk.Widget> prev = children.last ().prev;
         if (prev != null)
             (prev.data as GreeterList).greeter_box.pop ();
     }


### PR DESCRIPTION
Ubuntu 19.04 has uplifted valac to 0.43.91 pending the imminent release of stable 0.44.  Slick Greeter no longer builds.

This PR resolves this.

Also tested compilation under Ubuntu 18.04 which uses the older v0.40.8