### PR TITLE
Resolve lintian issues due to exe install locations

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -36,8 +36,11 @@ dist_pkgdata_DATA = \
 gsettings_SCHEMAS = x.dm.slick-greeter.gschema.xml
 
 dist_man1_MANS = \
-	slick-greeter.1 \
+	slick-greeter-set-keyboard-layout.1 \
 	slick-greeter-check-hidpi.1
+
+dist_man8_MANS = \
+	slick-greeter.8
 
 EXTRA_DIST = \
 	$(gsettings_SCHEMAS)

--- a/data/slick-greeter-set-keyboard-layout.1
+++ b/data/slick-greeter-set-keyboard-layout.1
@@ -1,0 +1,7 @@
+.TH SLICK-GREETER-SET-KEYBOARD-LAYOUT 1 2019-07-10 Linux "User commands"
+.SH NAME
+slick-greeter-set-keyboard-layout \- switch keyboard layout
+.SH DESCRIPTION
+.B internal executable to switch the keyboard layout
+.PP
+.SH OPTIONS

--- a/data/slick-greeter.8
+++ b/data/slick-greeter.8
@@ -1,4 +1,4 @@
-.TH SLICK-GREETER 1 "June 2, 2017"
+.TH SLICK-GREETER 8 2019-07-10 Linux "System management commands"
 .SH NAME
 slick-greeter \- distro agnostic LightDM greeter
 .SH SYNOPSIS


### PR DESCRIPTION
Hi,

  I maintain the Debian package for slick-greeter and today I was going to upload the latest v1.2.6 but I noticed that the build would have linitian issues that should really be resolved.  

This month's uplift to lintian in unstable now warns about commands installed in /usr/sbin such as slick-greeter that have man-pages not installed in man-pages section 8.

This PR ensures the slick-greeter man-page installs to the correct section 8 man-pages location.

I've also attached a stub slick-greeter-set-keyboard-layout man-page since the slick-greeter-set-keyboard-layout exe in /usr/bin needs this to resolve another lintian issue.