### PR TITLE
Fix sway badge size

### DIFF
--- a/files/usr/share/slick-greeter/badges/sway.svg
+++ b/files/usr/share/slick-greeter/badges/sway.svg
@@ -13,13 +13,14 @@
    id="Layer_1"
    x="0px"
    y="0px"
-   viewBox="1589.1 -0.1 371.0098 371.00976"
+   width="22"
+   height="22"
+   viewBox="0 0 22 22"
    enable-background="new 1589.1 -0.1 410.9 383.1"
    xml:space="preserve"
    sodipodi:docname="sway.svg"
    inkscape:version="0.92.4 5da689c313, 2019-01-14"
-   width="371.0098"
-   height="371.00977"><metadata
+   ><metadata
    id="metadata3929"><rdf:RDF><cc:Work
        rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
          rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
@@ -65,25 +66,25 @@
      id="g3896">
 	<g
    id="g3894">
-		
+
 	</g>
 </g><g
      id="g3902">
 	<g
    id="g3900">
-		
+
 	</g>
 </g><g
      id="g3922">
-	
-	
-	
-	
-	
-	
-	
+
+
+
+
+
+
+
 	<g
    id="g3920">
-		
+
 	</g>
 </g></g></svg>


### PR DESCRIPTION
Apparently the greeter doesn't automatically scale the svg's so change the icon to default to 22x22 pixels.