### PR TITLE
Feature/background span

### DIFF
--- a/data/x.dm.slick-greeter.gschema.xml
+++ b/data/x.dm.slick-greeter.gschema.xml
@@ -11,10 +11,10 @@
     </key>
     <key name="background-mode" type="s">
       <choices>
-        <choice value='scaled'/>
+        <choice value='zoom'/>
         <choice value='spanned'/>
       </choices>
-      <default>'scaled'</default>
+      <default>'zoom'</default>
       <summary>Determines how the background image is rendered</summary>
     </key>
     <key name="draw-user-backgrounds" type="b">

--- a/data/x.dm.slick-greeter.gschema.xml
+++ b/data/x.dm.slick-greeter.gschema.xml
@@ -9,6 +9,14 @@
       <default>'#000000'</default>
       <summary>Background color (e.g. #772953), set before wallpaper is seen</summary>
     </key>
+    <key name="background-mode" type="s">
+      <choices>
+        <choice value='scaled'/>
+        <choice value='spanned'/>
+      </choices>
+      <default>'scaled'</default>
+      <summary>Determines how the background image is rendered</summary>
+    </key>
     <key name="draw-user-backgrounds" type="b">
       <default>true</default>
       <summary>Whether to draw user backgrounds</summary>

--- a/src/background.vala
+++ b/src/background.vala
@@ -393,7 +393,7 @@ public class Background : Gtk.Fixed
         GRID,
         SPAN,
     }
-    private DrawFlags flags = NONE;
+    private DrawFlags flags = DrawFlags.NONE;
 
     /* Fallback color - shown upon first startup, until an async background loader finishes,
      * or until a user background or default background is loaded.

--- a/src/background.vala
+++ b/src/background.vala
@@ -464,6 +464,28 @@ public class Background : Gtk.Fixed
         }
     }
 
+    /* Width - total pixel width of the entire background canvas. This total width
+     * should account for the relative geometry of all attached monitors.
+     */
+
+    private int _width = 0;
+    public int width {
+        get {
+            return _width;
+        }
+    }
+
+    /* Height - total pixel height of the entire background canvas. This total height
+     * should account for the relative geometry of all attached monitors.
+     */
+
+    private int _height = 0;
+    public int height {
+        get {
+            return _height;
+        }
+    }
+
     public bool draw_grid { get; set; default = true; }
     public double alpha { get; private set; default = 1.0; }
     public Gdk.RGBA average_color { get { return current.average_color; } }
@@ -545,7 +567,15 @@ public class Background : Gtk.Fixed
     {
         this.monitors = new List<Monitor> ();
         foreach (var m in monitors)
+        {
+            if (_width < m.x + m.width)
+                _width = m.x + m.width;
+
+            if (_height < m.y + m.height)
+                _height = m.y + m.height;
+
             this.monitors.append (m);
+        }
         queue_draw ();
     }
 

--- a/src/background.vala
+++ b/src/background.vala
@@ -517,11 +517,11 @@ public class Background : Gtk.Fixed
         resize_mode = Gtk.ResizeMode.QUEUE;
         loaders = new HashTable<string?, BackgroundLoader> (str_hash, str_equal);
         if (UGSettings.get_boolean (UGSettings.KEY_DRAW_GRID))
-            flags |= GRID;
+            flags |= DrawFlags.GRID;
 
         var mode = UGSettings.get_string (UGSettings.KEY_BACKGROUND_MODE);
         if (mode == "spanned")
-            flags |= SPAN;
+            flags |= DrawFlags.SPAN;
 
         show ();
     }

--- a/src/greeter-list.vala
+++ b/src/greeter-list.vala
@@ -928,7 +928,6 @@ public abstract class GreeterList : FadableBox
         }
 
         /* Set the background */
-        background.draw_grid = false;
         background.queue_draw ();
     }
 

--- a/src/main-window.vala
+++ b/src/main-window.vala
@@ -32,8 +32,6 @@ public class MainWindow : Gtk.Window
     private Gtk.Box hbox;
     private Gtk.Button back_button;
     private ShutdownDialog? shutdown_dialog = null;
-    private int window_size_x;
-    private int window_size_y;
     private bool do_resize;
 
     public ListStack stack;
@@ -131,8 +129,6 @@ public class MainWindow : Gtk.Window
 
         add_user_list ();
 
-        window_size_x = 0;
-        window_size_y = 0;
         primary_monitor = null;
         do_resize = false;
 
@@ -147,7 +143,7 @@ public class MainWindow : Gtk.Window
             monitors.append (new Monitor (800, 120, 640, 480));
             background.set_monitors (monitors);
             move_to_monitor (monitors.nth_data (0));
-            resize (800 + 640, 600);
+            resize (background.width, background.height);
         }
         else
         {
@@ -212,7 +208,7 @@ public class MainWindow : Gtk.Window
     /* Setup the size and position of the window */
     public void setup_window ()
     {
-        resize (window_size_x, window_size_y);
+        resize (background.width, background.height);
         move (0, 0);
         move_to_monitor (primary_monitor);
     }
@@ -223,8 +219,6 @@ public class MainWindow : Gtk.Window
         Gdk.Monitor primary = display.get_primary_monitor();
         Gdk.Rectangle geometry;
 
-        window_size_x = 0;
-        window_size_y = 0;
         monitors = new List<Monitor> ();
         primary_monitor = null;
 
@@ -233,16 +227,6 @@ public class MainWindow : Gtk.Window
             Gdk.Monitor monitor = display.get_monitor(i);
             geometry = monitor.get_geometry ();
             debug ("Monitor %d is %dx%d pixels at %d,%d", i, geometry.width, geometry.height, geometry.x, geometry.y);
-
-            if (window_size_x < geometry.x + geometry.width)
-            {
-                window_size_x = geometry.x + geometry.width;
-            }
-
-            if (window_size_y < geometry.y + geometry.height)
-            {
-                window_size_y = geometry.y + geometry.height;
-            }
 
             if (monitor_is_unique_position (display, i))
             {
@@ -258,7 +242,7 @@ public class MainWindow : Gtk.Window
             }
         }
 
-        debug ("MainWindow is %dx%d pixels", window_size_x, window_size_y);
+        debug ("MainWindow is %dx%d pixels", background.width, background.height);
 
         background.set_monitors (monitors);
 

--- a/src/settings.vala
+++ b/src/settings.vala
@@ -22,6 +22,7 @@ public class UGSettings
 {
     public const string KEY_BACKGROUND = "background";
     public const string KEY_BACKGROUND_COLOR = "background-color";
+    public const string KEY_BACKGROUND_MODE = "background-mode";
     public const string KEY_DRAW_USER_BACKGROUNDS = "draw-user-backgrounds";
     public const string KEY_DRAW_GRID = "draw-grid";
     public const string KEY_SHOW_HOSTNAME = "show-hostname";
@@ -119,6 +120,7 @@ public class UGSettings
             var string_keys = new List<string> ();
             string_keys.append (KEY_BACKGROUND);
             string_keys.append (KEY_BACKGROUND_COLOR);
+            string_keys.append (KEY_BACKGROUND_MODE);
             string_keys.append (KEY_LOGO);
             string_keys.append (KEY_OTHER_MONITORS_LOGO);
             string_keys.append (KEY_THEME_NAME);


### PR DESCRIPTION
If `slick-greeter` is run with multiple monitors, the selected background image is simply replicated across each screen, scaled for each monitor's resolution. For those of us with multiple monitors on our desk, it can also be desirable to spread the background image across the entire rendering surface, instead of replicating the background. This pull request adds a new `background-mode` option which allows the user to select the desired rendering mode.

Currently, only two options are supported: "scaled", and "spanned". "Scaled" (the default) preserves the existing behavior of replicating the background across all monitors. "Spanned" instructs the greeter to instead treat all monitors as a single surface for background rendering. These options names were chosen to follow the precedent set by the `picture-options` key from the `org.cinnamon.desktop.background` schema.