### PR TITLE
Add clock-format to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,5 @@ Configuration file format for /etc/lightdm/slick-greeter.conf
     # enable-hidpi=Whether to enable HiDPI support (on/off/auto)
     # only-on-monitor=Sets the monitor on which to show the login window, -1 means "follow the mouse"
     # stretch-background-across-monitors=Whether to stretch the background across multiple monitors (false by default)
+    # clock-format=What clock format to use (e.g., %H:%M or %l:%M %p)
     [Greeter]

--- a/data/x.dm.slick-greeter.gschema.xml
+++ b/data/x.dm.slick-greeter.gschema.xml
@@ -135,5 +135,9 @@
       <default>'auto'</default>
       <summary>Monitor on which to show the GUI</summary>
     </key>
+    <key name="clock-format" type="s">
+      <default>'%H:%M'</default>
+      <summary>What clock format to use (e.g., %H:%M or %l:%M %p)</summary>
+    </key>
   </schema>
 </schemalist>

--- a/src/menubar.vala
+++ b/src/menubar.vala
@@ -123,6 +123,7 @@ public class MenuBar : Gtk.MenuBar
     }
 
     private string default_theme_name;
+    private string clock_format;
     private Gtk.CheckMenuItem high_contrast_item;
     private Pid keyboard_pid = 0;
     private Pid reader_pid = 0;
@@ -157,6 +158,7 @@ public class MenuBar : Gtk.MenuBar
             item.sensitive = false;
             item.show ();
             append (item);
+            clock_format = UGSettings.get_string (UGSettings.KEY_CLOCK_FORMAT);
             update_clock ();
             Timeout.add (1000, update_clock);
         }
@@ -339,7 +341,7 @@ public class MenuBar : Gtk.MenuBar
     private bool update_clock ()
     {
         var current_time = new DateTime.now_local ();
-        clock_label.set_label(current_time.format ("%H:%M"));
+        clock_label.set_label(current_time.format (clock_format));
         clock_label.set_tooltip_text (current_time.format ("%x"));
         return true;
     }

--- a/src/settings.vala
+++ b/src/settings.vala
@@ -49,6 +49,7 @@ public class UGSettings
     public const string KEY_ENABLE_HIDPI = "enable-hidpi";
     public const string KEY_ACTIVATE_NUMLOCK = "activate-numlock";
     public const string KEY_ONLY_ON_MONITOR = "only-on-monitor";
+    public const string KEY_CLOCK_FORMAT = "clock-format";
 
     public static bool get_boolean (string key)
     {
@@ -130,6 +131,7 @@ public class UGSettings
             string_keys.append (KEY_XFT_RGBA);
             string_keys.append (KEY_ENABLE_HIDPI);
             string_keys.append (KEY_ONLY_ON_MONITOR);
+            string_keys.append (KEY_CLOCK_FORMAT);
 
             var bool_keys = new List<string> ();
             bool_keys.append (KEY_DRAW_USER_BACKGROUNDS);


### PR DESCRIPTION
Allow clock format to be changed in `slick-greeter.conf`.