### PR TITLE
live session: Try to make sure no username entry is displayed in a live session

### DIFF
--- a/src/user-list.vala
+++ b/src/user-list.vala
@@ -1019,6 +1019,17 @@ public class UserList : GreeterList
                 offer_guest = true;
             }
 
+            string username = null, realname = null;
+            if (SlickGreeter.singleton.is_live_session (out username, out realname))
+            {
+                debug ("Adding live user account: %s (%s)", username, realname);
+
+                add_user (username, realname, null, true, false, null);
+
+                // lightdm might add itself to the user list when we do this.
+                remove_entry ("lightdm");
+            }
+
             /* If we have no entries at all, we should show manual */
             if (!have_entries ())
                 add_manual_entry ();


### PR DESCRIPTION
A change in accountsservice - https://gitlab.freedesktop.org/accountsservice/accountsservice/-/merge_requests/53 - causes our live session user to be prompted to enter the username because it's now considered a system (non-user) account owing to its uid of less than 1000 (999).