### PR TITLE
[Greeter] should be on top of the config lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A configuration tool is available at https://github.com/linuxmint/lightdm-settin
 
 Configuration file format for /etc/lightdm/slick-greeter.conf
 
+    [Greeter]
     # LightDM GTK+ Configuration
     # Available configuration options listed below.
     #
@@ -61,4 +62,4 @@ Configuration file format for /etc/lightdm/slick-greeter.conf
     # only-on-monitor=Sets the monitor on which to show the login window, -1 means "follow the mouse"
     # stretch-background-across-monitors=Whether to stretch the background across multiple monitors (false by default)
     # clock-format=What clock format to use (e.g., %H:%M or %l:%M %p)
-    [Greeter]
+    


### PR DESCRIPTION
Some people like me are definitely going to copy the code and paste it in slick-greeter.conf file. Then they will find themselves to be in a situation where uncommenting lines wouldn't work due to the position of [Greeter].

I only found out this because I checked out the lightdm-settings app. In fact I was going to switch to other greeters but just wanted to try something out again becaue to me slick-greeter is the best out-of-the-box greeter experience ever.

Happy to contribute.