### PR TITLE
Add a setting to configure the user list alignment

### DIFF
--- a/data/x.dm.slick-greeter.gschema.xml
+++ b/data/x.dm.slick-greeter.gschema.xml
@@ -151,5 +151,14 @@
       <default>'/usr/share/onboard/layouts/Small.onboard'</default>
       <summary>Path of the onscreen keyboard layout</summary>
     </key>
+    <key name="content-align" type="s">
+      <choices>
+        <choice value='left'/>
+        <choice value='center'/>
+        <choice value='right'/>
+      </choices>
+      <default>'left'</default>
+      <summary>Alignment of the main content</summary>
+    </key>
   </schema>
 </schemalist>

--- a/src/main-window.vala
+++ b/src/main-window.vala
@@ -30,6 +30,7 @@ public class MainWindow : Gtk.Window
     private Background background;
     private Gtk.Box login_box;
     private Gtk.Box hbox;
+    private Gtk.Box content_box;
     private Gtk.Button back_button;
     private ShutdownDialog? shutdown_dialog = null;
     private bool do_resize;
@@ -96,12 +97,40 @@ public class MainWindow : Gtk.Window
         menualign.add (menubar);
         SlickGreeter.add_style_class (menubar);
 
+        content_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+        content_box.expand = true;
+        content_box.show ();
+        login_box.add (content_box);
+
+        var content_align = UGSettings.get_string(UGSettings.KEY_CONTENT_ALIGN);
+        var x_align = 0.5f;
+
+        if (content_align == "left")
+        {
+            x_align = 0.0f;
+        }
+        else if (content_align == "right")
+        {
+            x_align = 1.0f;
+        }
+
+        var align = new Gtk.Alignment (x_align, 0.0f, 0.0f, 1.0f);
+
+        if (content_align == "center")
+        {
+            // offset for back button
+            align.margin_right = grid_size;
+        }
+
+        align.show ();
+        content_box.add (align);
+
         hbox = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
         hbox.expand = true;
         hbox.show ();
-        login_box.add (hbox);
+        align.add (hbox);
 
-        var align = new Gtk.Alignment (0.5f, 0.5f, 0.0f, 0.0f);
+        align = new Gtk.Alignment (0.5f, 0.5f, 0.0f, 0.0f);
         // Hack to avoid gtk 3.20's new allocate logic, which messes us up.
         align.resize_mode = Gtk.ResizeMode.QUEUE;
         align.set_size_request (grid_size, -1);
@@ -184,12 +213,13 @@ public class MainWindow : Gtk.Window
     {
         base.size_allocate (allocation);
 
-        if (hbox != null)
+        if (content_box != null)
         {
-            hbox.margin_left = get_grid_offset (get_allocated_width ()) + grid_size;
-            hbox.margin_right = get_grid_offset (get_allocated_width ());
-            hbox.margin_top = get_grid_offset (get_allocated_height ());
-            hbox.margin_bottom = get_grid_offset (get_allocated_height ());
+            var content_align = UGSettings.get_string(UGSettings.KEY_CONTENT_ALIGN);
+            content_box.margin_left = get_grid_offset (get_allocated_width ()) + (content_align == "left" ? grid_size : 0);
+            content_box.margin_right = get_grid_offset (get_allocated_width ()) + (content_align == "right" ? grid_size : 0);
+            content_box.margin_top = get_grid_offset (get_allocated_height ());
+            content_box.margin_bottom = get_grid_offset (get_allocated_height ());
         }
     }
 

--- a/src/settings.vala
+++ b/src/settings.vala
@@ -53,6 +53,7 @@ public class UGSettings
     public const string KEY_ONLY_ON_MONITOR = "only-on-monitor";
     public const string KEY_CLOCK_FORMAT = "clock-format";
     public const string KEY_ONSCREEN_KEYBOARD_LAYOUT = "onscreen-keyboard-layout";
+    public const string KEY_CONTENT_ALIGN = "content-align";
 
     public static bool get_boolean (string key)
     {
@@ -137,6 +138,7 @@ public class UGSettings
             string_keys.append (KEY_ONLY_ON_MONITOR);
             string_keys.append (KEY_CLOCK_FORMAT);
             string_keys.append (KEY_ONSCREEN_KEYBOARD_LAYOUT);
+            string_keys.append (KEY_CONTENT_ALIGN);
 
             var bool_keys = new List<string> ();
             bool_keys.append (KEY_DRAW_USER_BACKGROUNDS);


### PR DESCRIPTION
## Description
This PR adds an option to `slick-greeter` that controls the alignment of the main content (user list).
I'm not aware of any such feature request so I couldn't find any issue to link to this.
Apologies if this is not the correct process of submitting new features - this is my first contribution to the Linux Mint project.

I've also opened a fork of `lightdm-settings` to include a select that configures the alignment (https://github.com/eugeniodepalo/lightdm-settings/commit/8265c05a72d8784aa1edaade485395a884fedf6b)

Pre-built packages of the changes can be found in my PPA: https://launchpad.net/~eugenio-depalo/+archive/ubuntu/ppa

Any feedback is welcome.

### Center
![Linux Mint-2023-07-07-16-24-09](https://github.com/linuxmint/slick-greeter/assets/151741/48fc51e4-3a63-4216-8b14-5fb1f702a897)

### Right
![Linux Mint-2023-07-07-16-29-30](https://github.com/linuxmint/slick-greeter/assets/151741/3fa4cb96-79d9-4d17-bc5c-9f3276fd55af)


### Settings
![Linux Mint-2023-07-07-16-19-50](https://github.com/linuxmint/slick-greeter/assets/151741/2a56e751-9d06-4085-9636-a160bd2244d0)
