### PR TITLE
Resolve lintian issues due to missing man page

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -37,7 +37,8 @@ gsettings_SCHEMAS = x.dm.slick-greeter.gschema.xml
 
 dist_man1_MANS = \
 	slick-greeter-set-keyboard-layout.1 \
-	slick-greeter-check-hidpi.1
+	slick-greeter-check-hidpi.1 \
+	slick-greeter-enable-tap-to-click.1
 
 dist_man8_MANS = \
 	slick-greeter.8

--- a/data/slick-greeter-enable-tap-to-click.1
+++ b/data/slick-greeter-enable-tap-to-click.1
@@ -1,0 +1,7 @@
+.TH SLICK-GREETER-ENABLE-TAP-TO-CLICK 1 2023-07-16 Linux "User commands"
+.SH NAME
+slick-greeter-enable-tap-to-click \- enable tap-to-click
+.SH DESCRIPTION
+.B internal executable to enable touchpad tap-to-click
+.PP
+.SH OPTIONS


### PR DESCRIPTION
Hello,

I am part of the Ubuntu Budgie team, working with @fossfreedom , where we are maintaining the Debian packaging for slick greeter.

When creating the package for v1.8.1 of slick-greeter for upload to Debian, we noticed there was now a lintian warning regarding a missing man page:
W: slick-greeter: no-manual-page [usr/bin/slick-greeter-enable-tap-to-click]

This PR adds a stub slick-greeter-enable-tap-to-click man page to resolve this issue.