### PR TITLE
settings: Read config "onscreen-keyboard"

### DIFF
--- a/src/settings.vala
+++ b/src/settings.vala
@@ -151,6 +151,7 @@ public class UGSettings
             bool_keys.append (KEY_SHOW_KEYBOARD);
             bool_keys.append (KEY_SHOW_QUIT);
             bool_keys.append (KEY_XFT_ANTIALIAS);
+            bool_keys.append (KEY_ONSCREEN_KEYBOARD);
             bool_keys.append (KEY_ACTIVATE_NUMLOCK);
 
             var int_keys = new List<string> ();


### PR DESCRIPTION
The config option "onscreen-keyboard" takes no effect because it doesn't get read out. Add the missing read-out.

Fixes: #219