### PR TITLE
Get rid of gnome-common build dependency

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,20 +1,39 @@
 #!/bin/sh
 # Run this to generate all the initial makefiles, etc.
+test -n "$srcdir" || srcdir=$(dirname "$0")
+test -n "$srcdir" || srcdir=.
 
-srcdir=`dirname $0`
-test -z "$srcdir" && srcdir=.
+olddir=$(pwd)
 
-REQUIRED_AUTOMAKE_VERSION=1.7
+cd $srcdir
 
-(test -f $srcdir/configure.ac \
-  && test -d $srcdir/src) || {
-    echo -n "**Error**: Directory "\`$srcdir\'" does not look like the"
-    echo " top-level slick-greeter directory"
-    exit 1
+(test -f configure.ac) || {
+	echo "*** ERROR: Directory '$srcdir' does not look like the top-level project directory ***"
+	exit 1
 }
 
-which gnome-autogen.sh || {
-    echo "You need to install gnome-common from the GNOME CVS"
-    exit 1
-}
-. gnome-autogen.sh
+# shellcheck disable=SC2016
+PKG_NAME=$(autoconf --trace 'AC_INIT:$1' configure.ac)
+
+if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
+	echo "*** WARNING: I am going to run 'configure' with no arguments." >&2
+	echo "*** If you wish to pass any to it, please specify them on the" >&2
+	echo "*** '$0' command line." >&2
+	echo "" >&2
+fi
+
+aclocal --install || exit 1
+autoreconf --verbose --force --install || exit 1
+
+cd "$olddir"
+if [ "$NOCONFIGURE" = "" ]; then
+	$srcdir/configure "$@" || exit 1
+
+	if [ "$1" = "--help" ]; then
+		exit 0
+	else
+		echo "Now type 'make' to compile $PKG_NAME" || exit 1
+	fi
+else
+	echo "Skipping configure process."
+fi

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,6 @@ Standards-Version: 4.6.1
 Build-Depends: debhelper-compat (= 12),
                at-spi2-core,
                dbus-x11,
-               gnome-common,
                fonts-ubuntu,
                libcanberra-dev,
                libgtk-3-dev,


### PR DESCRIPTION
"gnome-common" is deprecated. Replace the autogen.sh script by the template suggested at the gnome-common migration page [1], adding the mentioned aclocal line.
- [1] https://wiki.gnome.org/Projects/GnomeCommon/Migration