### PR TITLE
Resize HEIGHT of greeter listbox on pam message

### DIFF
--- a/src/greeter-list.vala
+++ b/src/greeter-list.vala
@@ -823,6 +823,7 @@ public abstract class GreeterList : FadableBox
 
         /* Limit the number of characters in case a cat is sitting on the keyboard... */
         entry.max_length = MAX_FIELD_SIZE;
+        queue_resize ();
     }
 
     protected virtual void authentication_complete_cb ()


### PR DESCRIPTION
This partially fix #146

It dynamically resize height of greeter listbox when pam message received

I don't understand how to make something similar for width, so I simply change BOX_WIDTH constant:

```vala
-    public const int BOX_WIDTH = 8; /* in grid_size blocks */
+    public const int BOX_WIDTH = 22; /* in grid_size blocks */
``` 