### PR TITLE
Add xfce-wayland badge

### DIFF
--- a/files/usr/share/slick-greeter/badges/xfce-wayland.svg
+++ b/files/usr/share/slick-greeter/badges/xfce-wayland.svg
@@ -1,0 +1,1 @@
+xfce.svg


### PR DESCRIPTION
ref: https://github.com/Xubuntu/lightdm-gtk-greeter/pull/178
ref: https://gitlab.xfce.org/xfce/xfce4-session/-/blob/xfce-4.20pre1/xfce-wayland.desktop.in

<img src="https://github.com/user-attachments/assets/a79f2ce3-392e-4990-aa8f-de65793358dc" width=50%>

(For Xfce 4.20pre1, it should be possible to start xfce-wayland with lightdm after https://github.com/xfce-mirror/xfce4-session/commit/268e2fc55372a6f02567fd2739d0ac8f2f155205)