### PR TITLE
Fix conf location

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A slick-looking LightDM greeter
 
 - The default configuration is stored in dconf under the schema x.dm.slick-greeter.
 - Distributions should set their own defaults using a glib override.
-- Users can create and modify /etc/lightdm/slick-greeter.conf, settings in this files take priority and overwrite dconf settings.
+- Users can create and modify /etc/lightdm/lightdm.conf.d/slick-greeter.conf, settings in this files take priority and overwrite dconf settings.
 
 A configuration tool is available at https://github.com/linuxmint/lightdm-settings
 
@@ -26,7 +26,7 @@ A configuration tool is available at https://github.com/linuxmint/lightdm-settin
 
 ----
 
-Configuration file format for /etc/lightdm/slick-greeter.conf
+Configuration file format for /etc/lightdm/lightdm.conf.d/slick-greeter.conf
 
     [Greeter]
     # LightDM GTK+ Configuration

--- a/data/slick-greeter.8
+++ b/data/slick-greeter.8
@@ -26,7 +26,7 @@ Show help options.
 .SH Configuration File-Format
 .TP
 .TP
-.B /etc/lightdm/slick-greeter.conf
+.B /etc/lightdm/lightdm.conf.d/slick-greeter.conf
 .TP
 Available configuration options are listed below.
 .TP

--- a/src/settings.vala
+++ b/src/settings.vala
@@ -113,7 +113,7 @@ public class UGSettings
     public static void apply_conf_settings ()
     {
         try {
-            var path = "/etc/lightdm/slick-greeter.conf";
+            var path = "/etc/lightdm/lightdm.conf.d/slick-greeter.conf";
             var gsettings = new Settings (SCHEMA);
             var keyfile = new KeyFile ();
 


### PR DESCRIPTION
Lightdm ignores  slick-greeter.conf in it's current location

Fixes #253 #193  #113