### PR TITLE
Slick-greeter - Add user's avatar

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -27,6 +27,7 @@ slick_greeter_sources = files(
     'shutdown-dialog.vala',
     'toggle-box.vala',
     'slick-greeter.vala',
+    'user-avatar.vala',
     'user-list.vala',
     'user-prompt-box.vala',
 )

--- a/src/prompt-box.vala
+++ b/src/prompt-box.vala
@@ -127,7 +127,7 @@ public class PromptBox : FadableBox
 
         active_indicator = new ActiveIndicator ();
         active_indicator.valign = Gtk.Align.START;
-        active_indicator.margin_top = (grid_size - ActiveIndicator.HEIGHT) / 2;
+        active_indicator.margin_top = ((grid_size - ActiveIndicator.HEIGHT) / 2) + ActiveIndicator.MARGIN;
         active_indicator.show ();
         box_grid.attach (active_indicator, COL_ACTIVE, last_row, 1, 1);
 
@@ -209,7 +209,7 @@ public class PromptBox : FadableBox
         avatar_image = new UserAvatar();
         avatar_image.valign = Gtk.Align.START;
         avatar_image.halign = Gtk.Align.START;
-        avatar_image.margin_top = ActiveIndicator.WIDTH + box_grid.column_spacing - 2;
+        avatar_image.margin_top = (ActiveIndicator.WIDTH + box_grid.column_spacing) - ActiveIndicator.MARGIN;
         avatar_image.show();
         name_grid.attach (avatar_image, COL_AVATAR, ROW_NAME, 1, 1);
 
@@ -244,7 +244,7 @@ public class PromptBox : FadableBox
         option_button.halign = Gtk.Align.END;
         option_button.valign = Gtk.Align.START;
         // Keep as much space on top as on the right
-        option_button.margin_top = ActiveIndicator.WIDTH + box_grid.column_spacing - 2;
+        option_button.margin_top = (ActiveIndicator.WIDTH + box_grid.column_spacing) - ActiveIndicator.MARGIN;
         Gtk.button_set_focus_on_click (option_button, false);
         option_button.relief = Gtk.ReliefStyle.NONE;
         option_button.get_accessible ().set_name (_("Session Options"));
@@ -739,6 +739,7 @@ private class ActiveIndicator : Gtk.Image
     public bool active { get; set; }
     public const int WIDTH = 8;
     public const int HEIGHT = 7;
+    public const int MARGIN = 4;
 
     construct
     {

--- a/src/user-avatar.vala
+++ b/src/user-avatar.vala
@@ -1,0 +1,108 @@
+public class UserAvatar : CachedImage
+{
+    public const int AVATAR_SIZE = 32;
+    public const int AVATAR_MARGIN = 6;
+    public const double SMALL_AVATAR_OPACITY = 0.8;
+
+    private string? _avatar_path;
+    public string? avatar_path 
+    {
+        get { return _avatar_path; }
+        set { 
+            _avatar_path = value;
+            update_avatar();
+        }
+    }
+
+    private bool _is_small = false;
+    public bool is_small {
+        get { return _is_small; }
+        set {
+            _is_small = value;
+            update_avatar();
+        }
+    }
+
+    public UserAvatar()
+    {
+        Object();
+        setup_avatar();
+    }
+
+    private void setup_avatar()
+    {
+        // Keep a fixed size of 32px for display
+        set_size_request(AVATAR_SIZE, AVATAR_SIZE);
+        margin_right = AVATAR_MARGIN;
+        halign = Gtk.Align.CENTER;
+        hexpand = false;
+        vexpand = false;
+    }
+
+    private void update_avatar()
+    {
+        if (avatar_path != null)
+        {
+            try
+            {
+                // Double the pixel size for HiDPI
+                var scale_factor = get_scale_factor();
+                var pixel_size = AVATAR_SIZE * (scale_factor > 1 ? 2 : 1);
+                
+                var pixbuf = new Gdk.Pixbuf.from_file_at_scale(
+                    avatar_path,
+                    pixel_size,
+                    pixel_size,
+                    true
+                );
+
+                // Create a circular pixbuf
+                var surface = new Cairo.ImageSurface(
+                    Cairo.Format.ARGB32,
+                    pixel_size,
+                    pixel_size
+                );
+                var cr = new Cairo.Context(surface);
+                
+                // Draw a circle
+                cr.arc(
+                    pixel_size / 2.0,
+                    pixel_size / 2.0,
+                    pixel_size / 2.0,
+                    0,
+                    2 * Math.PI
+                );
+                cr.clip();
+                
+                // Draw the image with opacity if small
+                Gdk.cairo_set_source_pixbuf(cr, pixbuf, 0, 0);
+                if (is_small) {
+                    cr.paint_with_alpha(SMALL_AVATAR_OPACITY);
+                } else {
+                    cr.paint();
+                }
+                
+                // Convert surface to pixbuf and set it
+                var final_pixbuf = Gdk.pixbuf_get_from_surface(
+                    surface,
+                    0,
+                    0,
+                    pixel_size,
+                    pixel_size
+                );
+                
+                set_pixbuf(final_pixbuf);
+                show();
+            }
+            catch (Error e)
+            {
+                warning("Failed to load avatar: %s", e.message);
+                hide();
+            }
+        }
+        else
+        {
+            hide();
+        }
+    }
+}

--- a/src/user-list.vala
+++ b/src/user-list.vala
@@ -1079,6 +1079,13 @@ public class UserList : GreeterList
             label = user.name;
 
         add_user (user.name, label, user.background, user.logged_in, user.has_messages, user.session);
+
+        // Update avatar
+        var e = find_entry (user.name) as UserPromptBox;
+        if (e != null)
+        {
+            e.username = user.name;
+        }
     }
 
     private bool filter_group (string user_name)


### PR DESCRIPTION
This commit adds the user's avatar to the login screen :

 - LightDM is used to retrieve the user's image and libhandy isn't used.
- The avatar is automatically scaled in HiDPI mode.

![Screenshot](https://github.com/user-attachments/assets/cd578001-3972-41ce-bba2-2a09ffe09c19)
