### PR TITLE
locale: Load system locale from /etc/default/locale

### DIFF
--- a/src/slick-greeter.vala
+++ b/src/slick-greeter.vala
@@ -647,6 +647,29 @@ public class SlickGreeter
         }
     }
 
+    private static void load_locale ()
+    {
+        var file = File.new_for_path ("/etc/default/locale");
+        if (!file.query_exists ())
+            return;
+        try {
+            var dis = new DataInputStream (file.read ());
+            string line;
+            while ((line = dis.read_line (null)) != null) {
+                line = line.strip ();
+                if (line.has_prefix ("#") || !("=" in line))
+                    continue;
+                var parts = line.split ("=", 2);
+                var key = parts[0].strip ();
+                var val = parts[1].strip ().replace ("\"", "").replace ("'", "");
+                if (Environment.get_variable (key) == null)
+                    Environment.set_variable (key, val, true);
+            }
+        } catch (Error e) {
+            warning ("Failed to load locale: %s", e.message);
+        }
+    }
+
     private static void enable_tap_to_click ()
     {
         try {
@@ -698,6 +721,7 @@ public class SlickGreeter
         Environment.unset_variable ("UBUNTU_MENUPROXY");
 
         /* Initialize i18n */
+        load_locale ();
         Intl.setlocale (LocaleCategory.ALL, "");
         Intl.bindtextdomain (Config.GETTEXT_PACKAGE, Config.LOCALEDIR);
         Intl.bind_textdomain_codeset (Config.GETTEXT_PACKAGE, "UTF-8");


### PR DESCRIPTION
# Problem

When the system locale is configured in `/etc/default/locale` (e.g. `LANG=pt_BR.UTF-8`), PAM messages shown by slick-greeter during login (password expiry warnings, password quality checks) appear in English instead of the configured language.

The root cause is that LightDM does not load `/etc/default/locale` when spawning the greeter process. This is by design: in LightDM's `seat.c`, `create_greeter_session()` does not apply language configuration -> that
only happens for user sessions. As a result, the greeter inherits a minimal environment with no locale variables set.

The greeter already calls `Intl.setlocale(LocaleCategory.ALL, "")` at startup, but with no `LANG` or `LC_*` variables in the environment it always falls back to the `C` locale, and all PAM message translations are ignored.

## References

- LightDM source (seat.c): https://github.com/canonical/lightdm/blob/master/src/seat.c
- Original report: https://github.com/linuxmint/slick-greeter/issues/142 by [brunosoli](https://github.com/brunosoli).
- Related discussion in #77. 
- Also considered the solution commited by @clefebvre: https://github.com/linuxmint/slick-greeter/commit/1aa6d5888df372c677cbc06a770e7ab2e4f0c8b6

## Affected versions

**1.0.0** through **2.2.6** (current) - all Linux Mint releases from **18.3** (Sonya) to **22.3** (Zena).

### Steps to reproduce

1. Configure a non-English locale in `/etc/default/locale` (e.g. `LANG=pt_BR.UTF-8`).
2. Force a user's password to expire: `sudo chage -d 0 <user>`.
3. Log in as that user at the greeter -> the password change prompts appear in English instead of the configured locale.

### Expected behaviour

PAM messages shown by the greeter should honour the system locale configured in `/etc/default/locale`.

## Fix

Added `load_locale()` in `src/slick-greeter.vala`, called immediately before `Intl.setlocale()`. It reads `/etc/default/locale`, parses `KEY=value` lines (strips quotes, skips comments), and sets any missing locale environment variables. This is modeled on the existing `/etc/default/keyboard` reading pattern already used in `menubar.vala` (added in commit [1aa6d58](https://github.com/linuxmint/slick-greeter/commit/1aa6d5888df372c677cbc06a770e7ab2e4f0c8b6)).

Closes #142 
