### PR TITLE
Fix Vala deprecations and Meson warnings

### DIFF
--- a/files/meson.build
+++ b/files/meson.build
@@ -2,9 +2,11 @@ install_subdir(
     'usr' / 'bin',
     install_dir: bindir,
     strip_directory: true,
+    follow_symlinks: true,
 )
 
 install_subdir(
     'usr' / 'share',
     install_dir: prefix,
+    follow_symlinks: true,
 )

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('slick-greeter', 'vala', 'c', version : '2.2.6', meson_version : '>= 0.49.0')
+project('slick-greeter', 'vala', 'c', version : '2.2.6', meson_version : '>= 1.3.0')
 
 cc = meson.get_compiler('c')
 

--- a/src/animate-timer.vala
+++ b/src/animate-timer.vala
@@ -30,7 +30,7 @@ private class AnimateTimer : Object
     public const int SLOW =   1000; /* Good for animations that convey information that is only presented in the animation */
 
     /* speed is in milliseconds */
-    public unowned EasingFunc easing_func { get; private set; }
+    private unowned EasingFunc _easing_func;
     public int speed { get; set; }
     public bool is_running { get { return timeout != 0; } }
     public double progress { get; private set; }
@@ -55,7 +55,7 @@ private class AnimateTimer : Object
     public AnimateTimer (EasingFunc func, int speed)
     {
         Object (speed: speed);
-        this.easing_func = func;
+        this._easing_func = func;
     }
 
     ~AnimateTimer ()
@@ -124,7 +124,7 @@ private class AnimateTimer : Object
        time is not normalized yet! */
     private double calculate_progress (double time_progress)
     {
-        var y = easing_func (time_progress);
+        var y = _easing_func (time_progress);
         return y.clamp (0.0, 1.0);
     }
 

--- a/src/dash-box.vala
+++ b/src/dash-box.vala
@@ -183,6 +183,8 @@ public class DashBox : Gtk.Box
             force_immediate_layout_update ();
             rebuild_background ();
             break;
+        case Mode.NORMAL:
+            break;
         }
     }
 
@@ -270,28 +272,20 @@ public class DashBox : Gtk.Box
         {
             if (width > 0 && height > 0)
             {
-                try
+                bg_surface = new Cairo.ImageSurface (Cairo.Format.ARGB32, width, height);
+                var bg_cr = new Cairo.Context (bg_surface);
+                // Draw background in temporary surface
+                if (background != null)
                 {
-                    bg_surface = new Cairo.ImageSurface (Cairo.Format.ARGB32, width, height);
-                    var bg_cr = new Cairo.Context (bg_surface);
-                    // Draw background in temporary surface
-                    if (background != null)
-                    {
-                        int x, y;
-                        background.translate_coordinates (this, 0, 0, out x, out y);
-                        bg_cr.save ();
-                        bg_cr.translate (x, y);
-                        background.draw_full (bg_cr, Background.DrawFlags.NONE);
-                        bg_cr.restore ();
-                    }
-                    // Apply blur effect
-                    CairoUtils.ExponentialBlur.surface (bg_surface, BLUR_RADIUS);
+                    int x, y;
+                    background.translate_coordinates (this, 0, 0, out x, out y);
+                    bg_cr.save ();
+                    bg_cr.translate (x, y);
+                    background.draw_full (bg_cr, Background.DrawFlags.NONE);
+                    bg_cr.restore ();
                 }
-                catch (Error e)
-                {
-                    warning ("Failed to create background surface: %s", e.message);
-                    bg_surface = null;
-                }
+                // Apply blur effect
+                CairoUtils.ExponentialBlur.surface (bg_surface, BLUR_RADIUS);
             }
         }
 

--- a/src/dash-entry.vala
+++ b/src/dash-entry.vala
@@ -71,9 +71,18 @@ public class DashEntry : Gtk.Entry, Fadable
             }
         }
 
-        override_font (Pango.FontDescription.from_string (font));
-
         var style_ctx = get_style_context ();
+
+        try
+        {
+            var font_provider = new Gtk.CssProvider ();
+            font_provider.load_from_data ("entry { font-family: Ubuntu; font-size: 14pt; }", -1);
+            style_ctx.add_provider (font_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        }
+        catch (Error e)
+        {
+            debug ("Internal error loading font style: %s", e.message);
+        }
 
         try
         {

--- a/src/idle-monitor.vala
+++ b/src/idle-monitor.vala
@@ -59,7 +59,8 @@ public class IdleMonitor
             warning ("Only support idle monitor under X");
             return;
         }
-        display = (d as Gdk.X11.Display).get_xdisplay ();
+        var x11_display = (Gdk.X11.Display) d;
+        display = x11_display.get_xdisplay ();
 
         int sync_error_base;
         var res = X.Sync.QueryExtension (display, out sync_event_base, out sync_error_base);

--- a/src/list-stack.vala
+++ b/src/list-stack.vala
@@ -74,7 +74,11 @@ public class ListStack : Gtk.Fixed
 
         unowned List<weak Gtk.Widget> prev = children.last ().prev;
         if (prev != null)
-            (prev.data as GreeterList).greeter_box.pop ();
+        {
+            var prev_list = prev.data as GreeterList;
+            if (prev_list != null)
+                prev_list.greeter_box.pop ();
+        }
     }
 
     public override void size_allocate (Gtk.Allocation allocation)

--- a/src/main-window.vala
+++ b/src/main-window.vala
@@ -48,10 +48,22 @@ public class MainWindow : Gtk.Window
         add_accel_group (accel_group);
 
         var bg_color = Gdk.RGBA ();
+        set_name ("main-window");
         bg_color.parse (UGSettings.get_string (UGSettings.KEY_BACKGROUND_COLOR));
-        override_background_color (Gtk.StateFlags.NORMAL, bg_color);
+        try
+        {
+            var bg_provider = new Gtk.CssProvider ();
+            bg_provider.load_from_data (
+                "#main-window { background-color: %s; }".printf (bg_color.to_string ()), -1);
+            get_style_context ().add_provider (bg_provider,
+                                               Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        }
+        catch (Error e)
+        {
+            debug ("Internal error setting background color: %s", e.message);
+        }
         get_accessible ().set_name (_("Login Screen"));
-        has_resize_grip = false;
+        /* has_resize_grip = false — removed, deprecated since GTK 3.14 */
         SlickGreeter.add_style_class (this);
 
         background = new Background ();
@@ -64,7 +76,6 @@ public class MainWindow : Gtk.Window
 
         /* Box for menubar shadow */
         var menubox = new Gtk.EventBox ();
-        var menualign = new Gtk.Alignment (0.0f, 0.0f, 1.0f, 0.0f);
         var shadow_path = Path.build_filename (Config.PKGDATADIR,
                                                "shadow.png", null);
         var shadow_style = "";
@@ -86,15 +97,13 @@ public class MainWindow : Gtk.Window
         }
         menubox.set_size_request (-1, MENUBAR_HEIGHT);
         menubox.show ();
-        menualign.show ();
-        menubox.add (menualign);
         login_box.add (menubox);
-        SlickGreeter.add_style_class (menualign);
         SlickGreeter.add_style_class (menubox);
 
         menubar = new MenuBar (background, accel_group, this);
+        menubar.hexpand = true;
         menubar.show ();
-        menualign.add (menubar);
+        menubox.add (menubar);
         SlickGreeter.add_style_class (menubar);
 
         content_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
@@ -103,40 +112,34 @@ public class MainWindow : Gtk.Window
         login_box.add (content_box);
 
         var content_align = UGSettings.get_string(UGSettings.KEY_CONTENT_ALIGN);
-        var x_align = 0.5f;
 
+        hbox = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+        hbox.vexpand = true;
         if (content_align == "left")
-        {
-            x_align = 0.0f;
-        }
+            hbox.halign = Gtk.Align.START;
         else if (content_align == "right")
-        {
-            x_align = 1.0f;
-        }
-
-        var align = new Gtk.Alignment (x_align, 0.0f, 0.0f, 1.0f);
+            hbox.halign = Gtk.Align.END;
+        else
+            hbox.halign = Gtk.Align.CENTER;
 
         if (content_align == "center")
         {
             // offset for back button
-            align.margin_right = grid_size;
+            hbox.margin_end = grid_size;
         }
 
-        align.show ();
-        content_box.add (align);
-
-        hbox = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
-        hbox.expand = true;
         hbox.show ();
-        align.add (hbox);
+        content_box.add (hbox);
 
-        align = new Gtk.Alignment (0.5f, 0.5f, 0.0f, 0.0f);
+        var back_align = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
         // Hack to avoid gtk 3.20's new allocate logic, which messes us up.
-        align.resize_mode = Gtk.ResizeMode.QUEUE;
-        align.set_size_request (grid_size, -1);
-        align.margin_bottom = MENUBAR_HEIGHT; /* offset for menubar at top */
-        align.show ();
-        hbox.add (align);
+        back_align.resize_mode = Gtk.ResizeMode.QUEUE;
+        back_align.set_size_request (grid_size, -1);
+        back_align.margin_bottom = MENUBAR_HEIGHT;
+        back_align.halign = Gtk.Align.CENTER;
+        back_align.valign = Gtk.Align.CENTER;
+        back_align.show ();
+        hbox.add (back_align);
 
         back_button = new FlatButton ();
         back_button.get_accessible ().set_name (_("Back"));
@@ -146,15 +149,20 @@ public class MainWindow : Gtk.Window
         back_button.set_size_request (grid_size - GreeterList.BORDER * 2, grid_size - GreeterList.BORDER * 2);
         back_button.add (image);
         back_button.clicked.connect (pop_list);
-        align.add (back_button);
+        back_align.add (back_button);
 
-        align = new Gtk.Alignment (0.0f, 0.5f, 0.0f, 1.0f);
-        align.show ();
-        hbox.add (align);
+        var stack_align = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+        stack_align.halign = Gtk.Align.START;
+        stack_align.valign = Gtk.Align.FILL;
+        stack_align.vexpand = true;
+        stack_align.show ();
+        hbox.add (stack_align);
 
         stack = new ListStack ();
+        stack.valign = Gtk.Align.FILL;
+        stack.vexpand = true;
         stack.show ();
-        align.add (stack);
+        stack_align.add (stack);
 
         add_user_list ();
 
@@ -216,8 +224,8 @@ public class MainWindow : Gtk.Window
         if (content_box != null)
         {
             var content_align = UGSettings.get_string(UGSettings.KEY_CONTENT_ALIGN);
-            content_box.margin_left = get_grid_offset (get_allocated_width ()) + (content_align == "left" ? grid_size : 0);
-            content_box.margin_right = get_grid_offset (get_allocated_width ()) + (content_align == "right" ? grid_size : 0);
+            content_box.margin_start  = get_grid_offset (get_allocated_width ()) + (content_align == "left" ? grid_size : 0);
+            content_box.margin_end    = get_grid_offset (get_allocated_width ()) + (content_align == "right" ? grid_size : 0);
             content_box.margin_top = get_grid_offset (get_allocated_height ());
             content_box.margin_bottom = get_grid_offset (get_allocated_height ());
         }
@@ -226,7 +234,7 @@ public class MainWindow : Gtk.Window
     public override void realize ()
     {
         base.realize ();
-        background.set_surface (Gdk.cairo_create (get_window ()).get_target ());
+        background.set_surface (get_window ().create_similar_surface (Cairo.Content.COLOR, 1, 1));
     }
 
     public void before_session_start()

--- a/src/menubar.vala
+++ b/src/menubar.vala
@@ -85,6 +85,18 @@ public class MenuBar : Gtk.MenuBar
 
     private const int HEIGHT = 24;
 
+    private static void force_label_normal_color (Gtk.Label label)
+    {
+        try
+        {
+            var p = new Gtk.CssProvider ();
+             p.load_from_data ("label { color: @theme_fg_color; } " +
+                               "label:disabled { color: @theme_fg_color; }", -1);
+            label.get_style_context ().add_provider (p, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        }
+        catch (Error e) { debug ("MenuBar label color error: %s", e.message); }
+    }
+
     public MenuBar (Background bg, Gtk.AccelGroup ag, MainWindow mw)
     {
         Object (background: bg, accel_group: ag, main_window: mw);
@@ -100,30 +112,22 @@ public class MenuBar : Gtk.MenuBar
         {
             if (width > 0 && height > 0)
             {
-                try
+                bg_surface = new Cairo.ImageSurface (Cairo.Format.ARGB32, width, height);
+                var bg_cr = new Cairo.Context (bg_surface);
+
+                // Draw background in temporary surface
+                if (background != null)
                 {
-                    bg_surface = new Cairo.ImageSurface (Cairo.Format.ARGB32, width, height);
-                    var bg_cr = new Cairo.Context (bg_surface);
-                    
-                    // Draw background in temporary surface
-            if (background != null)
-            {
-                int x, y;
-                background.translate_coordinates (this, 0, 0, out x, out y);
-                        bg_cr.save ();
-                        bg_cr.translate (x, y);
-                        background.draw_full (bg_cr, Background.DrawFlags.NONE);
-                        bg_cr.restore ();
-                    }
-                    
-                    // Apply blur effect
-                    CairoUtils.ExponentialBlur.surface (bg_surface, BLUR_RADIUS);
+                    int x, y;
+                    background.translate_coordinates (this, 0, 0, out x, out y);
+                    bg_cr.save ();
+                    bg_cr.translate (x, y);
+                    background.draw_full (bg_cr, Background.DrawFlags.NONE);
+                    bg_cr.restore ();
                 }
-                catch (Error e)
-                {
-                    warning ("Failed to create background surface: %s", e.message);
-                    bg_surface = null;
-                }
+
+                // Apply blur effect
+                CairoUtils.ExponentialBlur.surface (bg_surface, BLUR_RADIUS);
             }
         }
 
@@ -198,9 +202,8 @@ public class MenuBar : Gtk.MenuBar
         if (UGSettings.get_boolean (UGSettings.KEY_SHOW_CLOCK))
         {
             clock_label = new Gtk.Label ("");
-            var clock_fg = clock_label.get_style_context ().get_color (Gtk.StateFlags.NORMAL);
-            clock_label.override_color (Gtk.StateFlags.INSENSITIVE, clock_fg);
             clock_label.show ();
+            force_label_normal_color (clock_label);
             var item = new Gtk.MenuItem ();
             item.add (clock_label);
             item.sensitive = false;
@@ -222,8 +225,7 @@ public class MenuBar : Gtk.MenuBar
             hbox.set_spacing (6);
             power_label = new Gtk.Label ("");
             power_label.sensitive = false;
-            var power_fg = power_label.get_style_context ().get_color (Gtk.StateFlags.NORMAL);
-            power_label.override_color (Gtk.StateFlags.INSENSITIVE, power_fg);
+            force_label_normal_color (power_label);
             power_label.show ();
             hbox.add (power_label);
             power_menu_item.add (hbox);
@@ -262,8 +264,7 @@ public class MenuBar : Gtk.MenuBar
         if (UGSettings.get_boolean (UGSettings.KEY_SHOW_HOSTNAME))
         {
             var label = new Gtk.Label (Posix.utsname ().nodename);
-            var hostname_fg = label.get_style_context ().get_color (Gtk.StateFlags.NORMAL);
-            label.override_color (Gtk.StateFlags.INSENSITIVE, hostname_fg);
+            force_label_normal_color (label);
             label.show ();
             var hostname_item = new Gtk.MenuItem ();
             hostname_item.add (label);
@@ -533,13 +534,12 @@ public class MenuBar : Gtk.MenuBar
         hbox.set_spacing (6);
         var label = new Gtk.Label ("");
         label.sensitive = false;
+        force_label_normal_color (label);
         var current_layout = LightDM.get_layout ();
         if (current_layout != null) {
             label.set_label (current_layout.name);
             item.set_tooltip_text(_("Keyboard layout:").concat(" ").concat(current_layout.description));
         }
-        var keyboard_fg = label.get_style_context ().get_color (Gtk.StateFlags.NORMAL);
-        label.override_color (Gtk.StateFlags.INSENSITIVE, keyboard_fg);
         label.show ();
         hbox.add (label);
         item.show ();
@@ -712,7 +712,7 @@ public class MenuBar : Gtk.MenuBar
                                      SpawnFlags.SEARCH_PATH,
                                      null,
                                      out reader_pid);
-                // This is a workaroud for bug https://launchpad.net/bugs/944159
+                // This is a workaround for bug https://launchpad.net/bugs/944159
                 // The problem is that orca seems to not notice that it's in a
                 // password field on startup.  We just need to kick orca in the
                 // pants.  We do this two ways:  a racy way and a non-racy way.
@@ -726,7 +726,12 @@ public class MenuBar : Gtk.MenuBar
                 // why we do both.  Ideally this would be fixed in orca itself.
                 SlickGreeter.singleton.orca_needs_kick = true;
                 Timeout.add_seconds (1, () => {
-                    Signal.emit_by_name ((get_toplevel () as Gtk.Window).get_focus ().get_accessible (), "focus-event", true);
+                    var win = get_toplevel () as Gtk.Window;
+                    if (win != null) {
+                        var focused = win.get_focus ();
+                        if (focused != null)
+                            Signal.emit_by_name (focused.get_accessible (), "focus-event", true);
+                    }
                     return false;
                 });
             }

--- a/src/prompt-box.vala
+++ b/src/prompt-box.vala
@@ -90,6 +90,33 @@ public class PromptBox : FadableBox
         Object (id: id);
     }
 
+    private static void apply_label_css (Gtk.Widget w, string family, int pt, bool bold = false)
+    {
+        try
+        {
+            var p = new Gtk.CssProvider ();
+            var weight = bold ? "bold" : "normal";
+            p.load_from_data (
+                "label { font-family: \"%s\"; font-size: %dpt; font-weight: %s; color: white; }".printf (family, pt, weight), -1);
+            w.get_style_context ().add_provider (p, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        }
+        catch (Error e) { debug ("CSS font error: %s", e.message); }
+    }
+
+    private static void apply_label_css_color (Gtk.Widget w, string family, int pt, Gdk.RGBA color, bool bold = false)
+    {
+        try
+        {
+            var p = new Gtk.CssProvider ();
+            var weight = bold ? "bold" : "normal";
+            p.load_from_data (
+                "label { font-family: \"%s\"; font-size: %dpt; font-weight: %s; color: %s; }".printf (
+                    family, pt, weight, color.to_string ()), -1);
+            w.get_style_context ().add_provider (p, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        }
+        catch (Error e) { debug ("CSS color error: %s", e.message); }
+    }
+
     construct
     {
         // Hack to avoid gtk 3.20's new allocate logic, which messes us up.
@@ -214,12 +241,11 @@ public class PromptBox : FadableBox
         name_grid.attach (avatar_image, COL_AVATAR, ROW_NAME, 1, 1);
 
         name_label = new FadingLabel ("");
-        name_label.override_font (Pango.FontDescription.from_string ("Ubuntu 13"));
-        name_label.override_color (Gtk.StateFlags.NORMAL, { 1.0f, 1.0f, 1.0f, 1.0f });
+        apply_label_css (name_label, "Ubuntu", 13);
         name_label.halign = Gtk.Align.START;
         name_label.valign = Gtk.Align.START;
         name_label.vexpand = false;
-        name_label.margin_left = 2;
+        name_label.margin_start = 2;
         name_label.margin_top = 4;
         name_label.set_size_request (-1, grid_size);
         name_label.show ();
@@ -230,7 +256,8 @@ public class PromptBox : FadableBox
         message_image.valign = Gtk.Align.CENTER;
         message_image.halign = Gtk.Align.CENTER;
 
-        var align = new Gtk.Alignment (0.5f, 0.5f, 0.0f, 0.0f);
+        var align = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+        align.halign = Gtk.Align.CENTER;
         align.valign = Gtk.Align.START;
         align.set_size_request (-1, grid_size);
         align.add (message_image);
@@ -272,12 +299,11 @@ public class PromptBox : FadableBox
         small_name_grid.attach (small_avatar_image, 0, 0, 1, 1);
 
         small_name_label = new FadingLabel ("");
-        small_name_label.override_font (Pango.FontDescription.from_string ("Ubuntu 13"));
-        small_name_label.override_color (Gtk.StateFlags.NORMAL, { 1.0f, 1.0f, 1.0f, 1.0f });
+        apply_label_css (small_name_label, "Ubuntu", 13);
         small_name_label.valign = Gtk.Align.CENTER;
         small_name_label.yalign = 0.5f;
         small_name_label.xalign = 0.0f;
-        small_name_label.margin_left = 2;
+        small_name_label.margin_start = 2;
         small_name_label.set_size_request (-1, grid_size);
         small_name_label.show ();
         small_name_grid.attach (small_name_label, 1, 0, 1, 1);
@@ -285,7 +311,9 @@ public class PromptBox : FadableBox
         small_message_image = new CachedImage (null);
         small_message_image.set_from_icon_name("mail-unread", Gtk.IconSize.BUTTON);
 
-        var align = new Gtk.Alignment (0.5f, 0.5f, 0.0f, 0.0f);
+        var align = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
+        align.halign = Gtk.Align.CENTER;
+        align.valign = Gtk.Align.CENTER;
         align.set_size_request (-1, grid_size);
         align.add (small_message_image);
         align.show ();
@@ -499,12 +527,10 @@ public class PromptBox : FadableBox
     {
         var label = new FadingLabel (text);
 
-        label.override_font (Pango.FontDescription.from_string ("Ubuntu Bold 10"));
-
         Gdk.RGBA color = { 1.0f, 1.0f, 1.0f, 1.0f };
         if (is_error)
             color.parse ("#ffd64d");
-        label.override_color (Gtk.StateFlags.NORMAL, color);
+        apply_label_css_color (label, "Ubuntu", 10, color, true);
 
         label.xalign = 0.0f;
         label.set_data<bool> ("prompt-box-is-error", is_error);
@@ -616,8 +642,18 @@ public class PromptBox : FadableBox
             combo = new Gtk.ComboBoxText.with_entry ();
 
         combo.get_style_context ().add_class ("lightdm-combo");
-        combo.get_child ().get_style_context ().add_class ("lightdm-combo");
-        combo.get_child ().override_font (Pango.FontDescription.from_string (DashEntry.font));
+        var combo_child = combo.get_child ();
+        if (combo_child != null)
+        {
+            combo_child.get_style_context ().add_class ("lightdm-combo");
+            try
+            {
+                var p = new Gtk.CssProvider ();
+                p.load_from_data ("entry { font-family: \"Ubuntu\"; font-size: 14pt; }", -1);
+                combo_child.get_style_context ().add_provider (p, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+            }
+            catch (Error e) { debug ("CSS combo entry error: %s", e.message); }
+        }
 
         attach_item (combo, false);
 

--- a/src/settings.vala
+++ b/src/settings.vala
@@ -65,7 +65,8 @@ public class UGSettings
     public static bool safe_get_boolean (string key, bool default)
     {
         var gsettings = new Settings (SCHEMA);
-        string[] keys = gsettings.list_keys ();
+        SettingsSchema schema = gsettings.settings_schema;
+        string[] keys = schema.list_keys ();
         foreach (var k in keys)
             if (k == key)
                 return gsettings.get_boolean (key);

--- a/src/shutdown-dialog.vala
+++ b/src/shutdown-dialog.vala
@@ -104,8 +104,7 @@ public class ShutdownDialog : Gtk.Fixed
         {
             var title_label = new Gtk.Label (_("Shut Down"));
             title_label.visible = true;
-            title_label.override_font (Pango.FontDescription.from_string ("Ubuntu Light 15"));
-            title_label.override_color (Gtk.StateFlags.NORMAL, { 1.0f, 1.0f, 1.0f, 1.0f });
+            title_label.get_style_context ().add_provider (make_label_style ("Ubuntu Light", 15), Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
             title_label.set_alignment (0.0f, 0.5f);
             vbox.pack_start (title_label, false, false, 0);
 
@@ -138,8 +137,7 @@ public class ShutdownDialog : Gtk.Fixed
 
         var label = new Gtk.Label (text);
         label.set_line_wrap (true);
-        label.override_font (Pango.FontDescription.from_string ("Ubuntu Light 12"));
-        label.override_color (Gtk.StateFlags.NORMAL, { 1.0f, 1.0f, 1.0f, 1.0f });
+        label.get_style_context ().add_provider (make_label_style ("Ubuntu Light", 12), Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
         label.set_alignment (0.0f, 0.5f);
         label.visible = true;
         vbox.pack_start (label, false, false, 0);
@@ -336,19 +334,25 @@ public class ShutdownDialog : Gtk.Fixed
 
     public void focus_next ()
     {
-        (get_toplevel () as Gtk.Window).move_focus (Gtk.DirectionType.TAB_FORWARD);
+        var w = get_toplevel () as Gtk.Window;
+        if (w != null)
+            w.move_focus (Gtk.DirectionType.TAB_FORWARD);
     }
 
     public void focus_prev ()
     {
-        (get_toplevel () as Gtk.Window).move_focus (Gtk.DirectionType.TAB_BACKWARD);
+        var w = get_toplevel () as Gtk.Window;
+        if (w != null)
+            w.move_focus (Gtk.DirectionType.TAB_BACKWARD);
     }
 
     public void cancel ()
     {
-        var widget = (get_toplevel () as Gtk.Window).get_focus ();
+        var w = get_toplevel () as Gtk.Window;
+        if (w == null) { close (); return; }
+        var widget = w.get_focus ();
         if (widget is DialogButton)
-            (get_toplevel () as Gtk.Window).set_focus (null);
+            w.set_focus (null);
         else
             close ();
     }
@@ -534,6 +538,22 @@ public class ShutdownDialog : Gtk.Fixed
     }
 }
 
+private Gtk.CssProvider make_label_style (string font_family, int size_pt)
+{
+    var provider = new Gtk.CssProvider ();
+    try
+    {
+        provider.load_from_data (
+            "label { font-family: \"%s\"; font-size: %dpt; color: white; }"
+            .printf (font_family, size_pt), -1);
+    }
+    catch (Error e)
+    {
+        debug ("CSS label style error: %s", e.message);
+    }
+    return provider;
+}
+
 private class DialogButton : Gtk.Button
 {
     private string inactive_filename;
@@ -558,10 +578,7 @@ private class DialogButton : Gtk.Button
         if (l != null)
         {
             l.visible = true;
-            l.override_font (Pango.FontDescription.from_string ("Ubuntu Light 12"));
-            l.override_color (Gtk.StateFlags.NORMAL, { 1.0f, 1.0f, 1.0f, 0.0f });
-            l.override_color (Gtk.StateFlags.FOCUSED, { 1.0f, 1.0f, 1.0f, 1.0f });
-            l.override_color (Gtk.StateFlags.ACTIVE, { 1.0f, 1.0f, 1.0f, 1.0f });
+            l.get_style_context ().add_provider (make_label_style ("Ubuntu Light", 12), Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
             this.get_accessible ().set_name (l.get_text ());
         }
 
@@ -587,7 +604,9 @@ private class DialogButton : Gtk.Button
 
     public override bool leave_notify_event (Gdk.EventCrossing event)
     {
-        (get_toplevel () as Gtk.Window).set_focus (null);
+        var w = get_toplevel () as Gtk.Window;
+        if (w != null)
+            w.set_focus (null);
         return base.leave_notify_event (event);
     }
 

--- a/src/slick-greeter.vala
+++ b/src/slick-greeter.vala
@@ -33,7 +33,7 @@ public class SlickGreeter
     private string state_file;
     private KeyFile state;
 
-    private Cairo.XlibSurface background_surface;
+    private Cairo.XlibSurface? background_surface;
 
     public bool orca_needs_kick;
     private MainWindow main_window;
@@ -246,7 +246,7 @@ public class SlickGreeter
         var display = Gdk.Display.get_default();
         var monitor = display.get_primary_monitor();
         var scale = monitor.get_scale_factor ();
-        background_surface.set_device_scale (scale, scale);
+        background_surface?.set_device_scale (scale, scale);
 
         /* Paint our background onto the root window before we close our own window */
         // var c = new Cairo.Context (background_surface);
@@ -490,7 +490,11 @@ public class SlickGreeter
                 /* Check to see if this window is our onboard window, since we don't want to focus it. */
                 X.Window keyboard_xid = 0;
                 if (main_window.menubar.keyboard_window != null)
-                    keyboard_xid = (main_window.menubar.keyboard_window.get_window () as Gdk.X11.Window).get_xid ();
+                {
+                    var x11_kwin = main_window.menubar.keyboard_window.get_window () as Gdk.X11.Window;
+                    if (x11_kwin != null)
+                        keyboard_xid = x11_kwin.get_xid ();
+                }
 
                 if (xwin != keyboard_xid && win.get_type_hint() != Gdk.WindowTypeHint.NOTIFICATION)
                 {
@@ -549,11 +553,18 @@ public class SlickGreeter
     {
         var visual = screen.get_system_visual ();
 
-        unowned X.Display display = (screen.get_display () as Gdk.X11.Display).get_xdisplay ();
-        unowned X.Screen xscreen = (screen as Gdk.X11.Screen).get_xscreen ();
+        var x11_display = screen.get_display () as Gdk.X11.Display;
+        var x11_screen  = screen as Gdk.X11.Screen;
+        var x11_root    = screen.get_root_window () as Gdk.X11.Window;
+        var x11_visual  = visual as Gdk.X11.Visual;
+        if (x11_display == null || x11_screen == null || x11_root == null || x11_visual == null)
+            return null;
+
+        unowned X.Display display = x11_display.get_xdisplay ();
+        unowned X.Screen xscreen  = x11_screen.get_xscreen ();
 
         var pixmap = X.CreatePixmap (display,
-                                     (screen.get_root_window () as Gdk.X11.Window).get_xid (),
+                                     x11_root.get_xid (),
                                      xscreen.width_of_screen (),
                                      xscreen.height_of_screen (),
                                      visual.get_depth ());
@@ -561,7 +572,7 @@ public class SlickGreeter
         /* Convert into a Cairo surface */
         var surface = new Cairo.XlibSurface (display,
                                              pixmap,
-                                             (visual as Gdk.X11.Visual).get_xvisual (),
+                                             x11_visual.get_xvisual (),
                                              xscreen.width_of_screen (), xscreen.height_of_screen ());
 
         return surface;
@@ -845,7 +856,10 @@ public class SlickGreeter
         debug ("Cleaning up");
 
         var screen = Gdk.Screen.get_default ();
-        unowned X.Display xdisplay = (screen.get_display () as Gdk.X11.Display).get_xdisplay ();
+        var x11_dpy = screen.get_display () as Gdk.X11.Display;
+        if (x11_dpy == null)
+            return 0;
+        unowned X.Display xdisplay = x11_dpy.get_xdisplay ();
 
         var window = xdisplay.default_root_window();
         var atom = xdisplay.intern_atom ("AT_SPI_BUS", true);

--- a/src/user-avatar.vala
+++ b/src/user-avatar.vala
@@ -32,7 +32,7 @@ public class UserAvatar : CachedImage
     {
         // Keep a fixed size of 32px for display
         set_size_request(AVATAR_SIZE, AVATAR_SIZE);
-        margin_right = AVATAR_MARGIN;
+        margin_end = AVATAR_MARGIN;
         halign = Gtk.Align.CENTER;
         hexpand = false;
         vexpand = false;

--- a/src/user-list.vala
+++ b/src/user-list.vala
@@ -602,7 +602,11 @@ public class UserList : GreeterList
         if (menubar.high_contrast || !UGSettings.get_boolean (UGSettings.KEY_DRAW_USER_BACKGROUNDS))
             new_background_file = null;
         else if (selected_entry is UserPromptBox)
-            new_background_file = (selected_entry as UserPromptBox).background;
+        {
+            var upb = selected_entry as UserPromptBox;
+            if (upb != null)
+                new_background_file = upb.background;
+        }
 
         background.current_background = new_background_file;
 
@@ -651,7 +655,10 @@ public class UserList : GreeterList
     {
         SlickGreeter.singleton.set_state ("last-user", username);
         if (selected_entry is UserPromptBox)
-            session = (selected_entry as UserPromptBox).session;
+        {
+            var upb = selected_entry as UserPromptBox;
+            session = (upb != null) ? upb.session : null;
+        }
         else
             session = null;
         selected_entry.clear ();


### PR DESCRIPTION
../src/settings.vala:68.25-68.43: warning: `GLib.Settings.list_keys' has been deprecated since 2.46
   68 |         string[] keys = gsettings.list_keys ();
      |                         ^~~~~~~~~~~~~~~~~~~    
../src/menubar.vala:729.42-729.82: warning: Access to possible `null'. Perform a check or use an unsafe cast.
  729 |                     Signal.emit_by_name ((get_toplevel () as Gtk.Window).get_focus ().get_accessible (), "focus-event", true);
      |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                            
../src/shutdown-dialog.vala:561.13-561.27: warning: `Gtk.Widget.override_font' has been deprecated since 3.16
  561 |             l.override_font (Pango.FontDescription.from_string ("Ubuntu Light 12"));
      |             ^~~~~~~~~~~~~~~                                                         
../src/shutdown-dialog.vala:562.13-562.28: warning: `Gtk.Widget.override_color' has been deprecated since 3.16
  562 |             l.override_color (Gtk.StateFlags.NORMAL, { 1.0f, 1.0f, 1.0f, 0.0f });
      |             ^~~~~~~~~~~~~~~~                                                     
../src/shutdown-dialog.vala:563.13-563.28: warning: `Gtk.Widget.override_color' has been deprecated since 3.16
  563 |             l.override_color (Gtk.StateFlags.FOCUSED, { 1.0f, 1.0f, 1.0f, 1.0f });
      |             ^~~~~~~~~~~~~~~~                                                      
../src/shutdown-dialog.vala:564.13-564.28: warning: `Gtk.Widget.override_color' has been deprecated since 3.16
  564 |             l.override_color (Gtk.StateFlags.ACTIVE, { 1.0f, 1.0f, 1.0f, 1.0f });
      |             ^~~~~~~~~~~~~~~~                                                     
../src/shutdown-dialog.vala:590.9-590.49: warning: Access to possible `null'. Perform a check or use an unsafe cast.
  590 |         (get_toplevel () as Gtk.Window).set_focus (null);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~        
../src/shutdown-dialog.vala:107.13-107.37: warning: `Gtk.Widget.override_font' has been deprecated since 3.16
  107 |             title_label.override_font (Pango.FontDescription.from_string ("Ubuntu Light 15"));
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~                                                         
../src/shutdown-dialog.vala:108.13-108.38: warning: `Gtk.Widget.override_color' has been deprecated since 3.16
  108 |             title_label.override_color (Gtk.StateFlags.NORMAL, { 1.0f, 1.0f, 1.0f, 1.0f });
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~                                                     
../src/shutdown-dialog.vala:141.9-141.27: warning: `Gtk.Widget.override_font' has been deprecated since 3.16
  141 |         label.override_font (Pango.FontDescription.from_string ("Ubuntu Light 12"));
      |         ^~~~~~~~~~~~~~~~~~~                                                         
../src/shutdown-dialog.vala:142.9-142.28: warning: `Gtk.Widget.override_color' has been deprecated since 3.16
  142 |         label.override_color (Gtk.StateFlags.NORMAL, { 1.0f, 1.0f, 1.0f, 1.0f });
      |         ^~~~~~~~~~~~~~~~~~~~                                                     
../src/shutdown-dialog.vala:339.9-339.50: warning: Access to possible `null'. Perform a check or use an unsafe cast.
  339 |         (get_toplevel () as Gtk.Window).move_focus (Gtk.DirectionType.TAB_FORWARD);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                 
../src/shutdown-dialog.vala:344.9-344.50: warning: Access to possible `null'. Perform a check or use an unsafe cast.
  344 |         (get_toplevel () as Gtk.Window).move_focus (Gtk.DirectionType.TAB_BACKWARD);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                  
../src/shutdown-dialog.vala:349.22-349.62: warning: Access to possible `null'. Perform a check or use an unsafe cast.
  349 |         var widget = (get_toplevel () as Gtk.Window).get_focus ();
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    
../src/shutdown-dialog.vala:351.13-351.53: warning: Access to possible `null'. Perform a check or use an unsafe cast.
  351 |             (get_toplevel () as Gtk.Window).set_focus (null);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~        
../src/menubar.vala:542.9-542.28: warning: `Gtk.Widget.override_color' has been deprecated since 3.16
  542 |         label.override_color (Gtk.StateFlags.INSENSITIVE, keyboard_fg);
      |         ^~~~~~~~~~~~~~~~~~~~                                           
../src/menubar.vala:202.13-202.38: warning: `Gtk.Widget.override_color' has been deprecated since 3.16
  202 |             clock_label.override_color (Gtk.StateFlags.INSENSITIVE, clock_fg);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~                                        
../src/menubar.vala:226.13-226.38: warning: `Gtk.Widget.override_color' has been deprecated since 3.16
  226 |             power_label.override_color (Gtk.StateFlags.INSENSITIVE, power_fg);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~                                        
../src/menubar.vala:266.13-266.32: warning: `Gtk.Widget.override_color' has been deprecated since 3.16
  266 |             label.override_color (Gtk.StateFlags.INSENSITIVE, hostname_fg);
      |             ^~~~~~~~~~~~~~~~~~~~                                           
../src/user-avatar.vala:35.9-35.20: warning: `Gtk.Widget.margin_right' has been deprecated since 3.12
   35 |         margin_right = AVATAR_MARGIN;
      |         ^~~~~~~~~~~~                 
../src/prompt-box.vala:217.9-217.32: warning: `Gtk.Widget.override_font' has been deprecated since 3.16
  217 |         name_label.override_font (Pango.FontDescription.from_string ("Ubuntu 13"));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~                                                   
../src/prompt-box.vala:218.9-218.33: warning: `Gtk.Widget.override_color' has been deprecated since 3.16
  218 |         name_label.override_color (Gtk.StateFlags.NORMAL, { 1.0f, 1.0f, 1.0f, 1.0f });
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~                                                     
../src/prompt-box.vala:222.9-222.30: warning: `Gtk.Widget.margin_left' has been deprecated since 3.12
  222 |         name_label.margin_left = 2;
      |         ^~~~~~~~~~~~~~~~~~~~~~     
../src/prompt-box.vala:233.25-233.37: warning: `Gtk.Alignment' has been deprecated since 3.14
  233 |         var align = new Gtk.Alignment (0.5f, 0.5f, 0.0f, 0.0f);
      |                         ^~~~~~~~~~~~~                          
../src/prompt-box.vala:233.13-233.17: warning: `Gtk.Alignment' has been deprecated since 3.14
  233 |         var align = new Gtk.Alignment (0.5f, 0.5f, 0.0f, 0.0f);
      |             ^~~~~                                              
../src/prompt-box.vala:275.9-275.38: warning: `Gtk.Widget.override_font' has been deprecated since 3.16
  275 |         small_name_label.override_font (Pango.FontDescription.from_string ("Ubuntu 13"));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                   
../src/prompt-box.vala:276.9-276.39: warning: `Gtk.Widget.override_color' has been deprecated since 3.16
  276 |         small_name_label.override_color (Gtk.StateFlags.NORMAL, { 1.0f, 1.0f, 1.0f, 1.0f });
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                     
../src/prompt-box.vala:280.9-280.36: warning: `Gtk.Widget.margin_left' has been deprecated since 3.12
  280 |         small_name_label.margin_left = 2;
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~     
../src/prompt-box.vala:288.25-288.37: warning: `Gtk.Alignment' has been deprecated since 3.14
  288 |         var align = new Gtk.Alignment (0.5f, 0.5f, 0.0f, 0.0f);
      |                         ^~~~~~~~~~~~~                          
../src/prompt-box.vala:288.13-288.17: warning: `Gtk.Alignment' has been deprecated since 3.14
  288 |         var align = new Gtk.Alignment (0.5f, 0.5f, 0.0f, 0.0f);
      |             ^~~~~                                              
../src/dash-entry.vala:74.9-74.21: warning: `Gtk.Widget.override_font' has been deprecated since 3.16
   74 |         override_font (Pango.FontDescription.from_string (font));
      |         ^~~~~~~~~~~~~                                            
../src/prompt-box.vala:502.9-502.27: warning: `Gtk.Widget.override_font' has been deprecated since 3.16
  502 |         label.override_font (Pango.FontDescription.from_string ("Ubuntu Bold 10"));
      |         ^~~~~~~~~~~~~~~~~~~                                                        
../src/prompt-box.vala:507.9-507.28: warning: `Gtk.Widget.override_color' has been deprecated since 3.16
  507 |         label.override_color (Gtk.StateFlags.NORMAL, color);
      |         ^~~~~~~~~~~~~~~~~~~~                                
../src/prompt-box.vala:620.9-620.40: warning: `Gtk.Widget.override_font' has been deprecated since 3.16
  620 |         combo.get_child ().override_font (Pango.FontDescription.from_string (DashEntry.font));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                      
../src/list-stack.vala:77.13-77.50: warning: Access to possible `null'. Perform a check or use an unsafe cast.
   77 |             (prev.data as GreeterList).greeter_box.pop ();
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~        
../src/main-window.vala:219.13-219.35: warning: `Gtk.Widget.margin_left' has been deprecated since 3.12
  219 |             content_box.margin_left = get_grid_offset (get_allocated_width ()) + (content_align == "left" ? grid_size : 0);
      |             ^~~~~~~~~~~~~~~~~~~~~~~                                                                                        
../src/main-window.vala:220.13-220.36: warning: `Gtk.Widget.margin_right' has been deprecated since 3.12
  220 |             content_box.margin_right = get_grid_offset (get_allocated_width ()) + (content_align == "right" ? grid_size : 0);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~                                                                                         
../src/main-window.vala:229.33-229.48: warning: `Gdk.cairo_create' has been deprecated since 3.22
  229 |         background.set_surface (Gdk.cairo_create (get_window ()).get_target ());
      |                                 ^~~~~~~~~~~~~~~~                                
../src/user-list.vala:605.35-605.78: warning: Access to possible `null'. Perform a check or use an unsafe cast.
  605 |             new_background_file = (selected_entry as UserPromptBox).background;
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
../src/user-list.vala:654.23-654.63: warning: Access to possible `null'. Perform a check or use an unsafe cast.
  654 |             session = (selected_entry as UserPromptBox).session;
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
../src/main-window.vala:52.9-52.33: warning: `Gtk.Widget.override_background_color' has been deprecated since 3.16
   52 |         override_background_color (Gtk.StateFlags.NORMAL, bg_color);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~                                   
../src/main-window.vala:54.9-54.23: warning: `Gtk.Window.has_resize_grip' has been deprecated since 3.14
   54 |         has_resize_grip = false;
      |         ^~~~~~~~~~~~~~~         
../src/main-window.vala:67.29-67.41: warning: `Gtk.Alignment' has been deprecated since 3.14
   67 |         var menualign = new Gtk.Alignment (0.0f, 0.0f, 1.0f, 0.0f);
      |                             ^~~~~~~~~~~~~                          
../src/main-window.vala:67.13-67.21: warning: `Gtk.Alignment' has been deprecated since 3.14
   67 |         var menualign = new Gtk.Alignment (0.0f, 0.0f, 1.0f, 0.0f);
      |             ^~~~~~~~~                                              
../src/main-window.vala:117.25-117.37: warning: `Gtk.Alignment' has been deprecated since 3.14
  117 |         var align = new Gtk.Alignment (x_align, 0.0f, 0.0f, 1.0f);
      |                         ^~~~~~~~~~~~~                             
../src/main-window.vala:117.13-117.17: warning: `Gtk.Alignment' has been deprecated since 3.14
  117 |         var align = new Gtk.Alignment (x_align, 0.0f, 0.0f, 1.0f);
      |             ^~~~~                                                 
../src/main-window.vala:122.13-122.30: warning: `Gtk.Widget.margin_right' has been deprecated since 3.12
  122 |             align.margin_right = grid_size;
      |             ^~~~~~~~~~~~~~~~~~             
../src/main-window.vala:133.21-133.33: warning: `Gtk.Alignment' has been deprecated since 3.14
  133 |         align = new Gtk.Alignment (0.5f, 0.5f, 0.0f, 0.0f);
      |                     ^~~~~~~~~~~~~                          
../src/main-window.vala:151.21-151.33: warning: `Gtk.Alignment' has been deprecated since 3.14
  151 |         align = new Gtk.Alignment (0.0f, 0.5f, 0.0f, 1.0f);
      |                     ^~~~~~~~~~~~~                          
../src/slick-greeter.vala:552.37-552.91: warning: Access to possible `null'. Perform a check or use an unsafe cast.
  552 |         unowned X.Display display = (screen.get_display () as Gdk.X11.Display).get_xdisplay ();
      |                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    
../src/slick-greeter.vala:553.36-553.73: warning: Access to possible `null'. Perform a check or use an unsafe cast.
  553 |         unowned X.Screen xscreen = (screen as Gdk.X11.Screen).get_xscreen ();
      |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    
../src/slick-greeter.vala:556.38-556.90: warning: Access to possible `null'. Perform a check or use an unsafe cast.
  556 |                                      (screen.get_root_window () as Gdk.X11.Window).get_xid (),
      |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    
../src/slick-greeter.vala:564.46-564.83: warning: Access to possible `null'. Perform a check or use an unsafe cast.
  564 |                                              (visual as Gdk.X11.Visual).get_xvisual (),
      |                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    
../src/slick-greeter.vala:493.36-493.112: warning: Access to possible `null'. Perform a check or use an unsafe cast.
  493 |                     keyboard_xid = (main_window.menubar.keyboard_window.get_window () as Gdk.X11.Window).get_xid ();
      |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    
../src/slick-greeter.vala:848.38-848.92: warning: Access to possible `null'. Perform a check or use an unsafe cast.
  848 |         unowned X.Display xdisplay = (screen.get_display () as Gdk.X11.Display).get_xdisplay ();
      |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    
../src/idle-monitor.vala:62.19-62.53: warning: Access to possible `null'. Perform a check or use an unsafe cast.
   62 |         display = (d as Gdk.X11.Display).get_xdisplay ();
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    
../src/dash-box.vala:156.9-156.21: warning: Switch does not handle `NORMAL' of enum `DashBox.Mode'
  156 |         switch (mode)
      |         ^~~~~~~~~~~~~
../src/dash-box.vala:290.17-290.31: warning: unreachable catch clause detected
  290 |                 catch (Error e)
      |                 ^~~~~~~~~~~~~~~
../src/menubar.vala:122.17-122.31: warning: unreachable catch clause detected
  122 |                 catch (Error e)
      |                 ^~~~~~~~~~~~~~~
../src/animate-timer.vala:33.5-33.41: warning: Type `AnimateTimer.EasingFunc' can not be used for a GLib.Object property
   33 |     public unowned EasingFunc easing_func { get; private set; }
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                      
Compilation succeeded - 60 warning(s)