### PR TITLE
Adjusted high definition DPI cut-off and added configurable override

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Configuration file format for /etc/lightdm/slick-greeter.conf
     # hidden-users=List of usernames (separated by semicolons) that are hidden until Ctr+Alt+Shift is pressed
     # group-filter=List of groups that users must be part of to be shown (empty list shows all users)
     # enable-hidpi=Whether to enable HiDPI support (on/off/auto)
+    # hidpi-detection-cutoff=DPI value above which the display is considered HiDPI when enable-hidpi is "auto" (144 by default)
     # only-on-monitor=Sets the monitor on which to show the login window, -1 means "follow the mouse"
     # stretch-background-across-monitors=Whether to stretch the background across multiple monitors (false by default)
     # clock-format=What clock format to use (e.g., %H:%M or %l:%M %p)

--- a/files/usr/bin/slick-greeter-check-hidpi
+++ b/files/usr/bin/slick-greeter-check-hidpi
@@ -6,8 +6,22 @@ from gi.repository import Gdk
 import sys
 import os
 import syslog
+import configparser
 
-HIDPI_LIMIT = 192
+HIDPI_LIMIT_DEFAULT = 144
+CONF_PATH = "/etc/lightdm/slick-greeter.conf"
+
+def get_hidpi_limit():
+    limit = HIDPI_LIMIT_DEFAULT
+    config = configparser.ConfigParser()
+    try:
+        if config.read(CONF_PATH) and config.has_option("Greeter", "hidpi-detection-cutoff"):
+            limit = config.getint("Greeter", "hidpi-detection-cutoff")
+    except Exception as detail:
+        syslog.syslog("Error while reading hidpi-detection-cutoff from %s: %s" % (CONF_PATH, detail))
+    return limit
+
+HIDPI_LIMIT = get_hidpi_limit()
 
 def get_window_scale():
     window_scale = 1


### PR DESCRIPTION
My 24" 4k monitor is high definition and calculated pixel density is ~184 DPI. The auto hi-definition script previously used 192 DPI as the cut-off for high definition monitor detection and classified it as normal definition, making UI elements too small.

This PR changes the default cut-off to 144 DPI (halfway between the "standard" DPI values of 96 dpi for normal definition and 192 DPI for high definition displays), and adds (and documents) a config file option `hidpi-detection-cutoff` to set a custom cut-off value.